### PR TITLE
Added the feature to auto create the queue on SQS

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -131,6 +131,9 @@ class ServerlessOfflineSQS {
 
     this.serverless.cli.log(`${queueName}`);
 
+    const params = {QueueName: queueName};
+    await fromCallback(cb => client.createQueue(params, cb));
+
     const {QueueUrl} = await fromCallback(cb =>
       client.getQueueUrl(
         {


### PR DESCRIPTION
@godu Currently the sqs plugin doesn't create the queues declared at resources.
Maybe we could add this feature?
I made this PR as a suggestion and it refers to [#19 issue](https://github.com/godu/serverless/issues/19). It try to create the queue only using the queue name. If the queue already exists nothing change.