### PR TITLE
Issue #29: extended readme

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -2,7 +2,8 @@
 
 This Serverless-offline plugin emulates AWS λ and SQS queue on your local machine. To do so, it listens SQS queue and invokes your handlers.
 
-*Features*:
+_Features_:
+
 - [Serverless Webpack](https://github.com/serverless-heaven/serverless-webpack/) support.
 - SQS configurations: batchsize.
 
@@ -24,6 +25,16 @@ plugins:
 ```
 
 [See example](./example/README.md)
+
+## How it works?
+
+To be able to emulate AWS SQS queue on local machine there should be some queue system actually running. One of the existing implementations suitable for the task is [ElasticMQ](https://github.com/adamw/elasticmq).
+
+[ElasticMQ](https://github.com/adamw/elasticmq) is a standalone in-memory queue system, which implements AWS SQS compatible interface. It can be run either stand-alone or inside Docker container. See [example](./example/docker-compose.yml) `sqs` service setup.
+
+We also need to setup actual queue in ElasticMQ server, we can use [AWS cli](https://aws.amazon.com/cli/) tools for that. In example, we spawn-up another container with `aws-cli` pre-installed and run initialization script, against ElasticMQ server in separate container.
+
+Once ElasticMQ is running and initialized, we can proceed with the configuration of the plugin.
 
 ## Configure
 


### PR DESCRIPTION
Issue #29 

Extended serverless `sqs-offine` documentation to give a little clue how the plugin infrastructure should be set up.