### PR TITLE
Readme documentation Queue name to match example

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -52,7 +52,7 @@ functions:
               - Arn
 resources:
   Resources:
-    MyFirstQueue:
+    MyFourthQueue:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: MyFourthQueue


### PR DESCRIPTION
The queue name was wrong in the Readme which caused initial confusion.  Just the tiniest update to help "Get started" easily.