### PR TITLE
guard undefined shard iterator for dynamodb-local

### DIFF
--- a/packages/dynamodb-streams-readable/src/index.js
+++ b/packages/dynamodb-streams-readable/src/index.js
@@ -92,7 +92,7 @@ function DynamoDBStreamReadable(client, arn, options) {
   }
 
   function read(callback) {
-    if (drain && !pending || !iterator) return callback(null, {Records: null});
+    if ((drain && !pending) || !iterator) return callback(null, {Records: null});
     if (drain && pending) return setImmediate(read, callback);
 
     pending++;

--- a/packages/dynamodb-streams-readable/src/index.js
+++ b/packages/dynamodb-streams-readable/src/index.js
@@ -92,9 +92,8 @@ function DynamoDBStreamReadable(client, arn, options) {
   }
 
   function read(callback) {
-    if (drain && !pending) return callback(null, {Records: null});
+    if (drain && !pending || !iterator) return callback(null, {Records: null});
     if (drain && pending) return setImmediate(read, callback);
-    if (!iterator) return callback(null);
 
     pending++;
     client.getRecords(

--- a/packages/dynamodb-streams-readable/src/index.js
+++ b/packages/dynamodb-streams-readable/src/index.js
@@ -94,6 +94,7 @@ function DynamoDBStreamReadable(client, arn, options) {
   function read(callback) {
     if (drain && !pending) return callback(null, {Records: null});
     if (drain && pending) return setImmediate(read, callback);
+    if (!iterator) return callback(null);
 
     pending++;
     client.getRecords(


### PR DESCRIPTION
Detail: when running `sls offline start` with a dynamodb-local, there is an instance where the shard iterator is undefined when using a dynamodb-local that has been alive for the more than a day. The describe shard iterator function will throw an error because ShardIterator was not provided. The work around that I've found so far is to destroy and recreate your dynamodb-local and start fresh.

Currently using local serverless-offline with docker compose for dependencies like s3, sqs, dyamodb, elasticsearch etc, just to give some background info