### PR TITLE
Ignore error propagated from handler function

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -168,7 +168,9 @@ class ServerlessOfflineSQS {
       );
 
       if (Messages) {
-        await fromCallback(cb => this.eventHandler(queueEvent, functionName, Messages, cb));
+        await fromCallback(cb => this.eventHandler(queueEvent, functionName, Messages, cb)).catch(
+          () => {}
+        );
 
         await fromCallback(cb =>
           client.deleteMessageBatch(


### PR DESCRIPTION
If Lambda function errors (callback style error or async one) SQS client brakes with "unhandled promise rejection" and never recovers, which means that you need to re-start serverless offline process. This happens because `fromCallback` converts callback error to promise which is not handled in this case.

Also question with failing handler, should this library leave SQS message in queue in this case, and allow it to be re-tried? Currently message is deleted after handler is invoked. 