### PR TITLE
Adding `getOr` to avoid error on no custom config

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -7,6 +7,7 @@ const {
   filter,
   forEach,
   get,
+  getOr,
   isEmpty,
   isUndefined,
   map,
@@ -31,7 +32,7 @@ const fromCallback = fun =>
 const printBlankLine = () => console.log();
 
 const getConfig = (service, options, pluginName) => {
-  return Object.assign(get(['custom', pluginName], service), omitBy(isUndefined, options));
+  return Object.assign(getOr({}, ['custom', pluginName], service), omitBy(isUndefined, options));
 };
 
 const extractTableNameFromARN = arn => {


### PR DESCRIPTION
## What does this PR do?

Updates `getConfig` on  `src/index.js` to use `getOr` when getting the config to avoid the following error when there's no custom config for a plugin:

```
in serverless-offline-dynamodb-streams/src/index.js:35:

return Object.assign(get(['custom', pluginName], service), omitBy(isUndefined, options));
              ^

TypeError: Cannot convert undefined or null to object
```