### PR TITLE
Release eventHandler promise after successfully handle messages

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -153,6 +153,8 @@ class ServerlessOfflineSQS {
     else if (x instanceof Error) lambdaContext.fail(x);
 
     process.env = env;
+
+    cb();
   }
 
   async createQueueReadable(functionName, queueEvent) {


### PR DESCRIPTION
## What does this PR do?

Using `serverless-offline` with `serverless-offline-sqs` when lambda function get triggered by SQS it doesn't get re-triggered by a new message.

The `eventHandler` function doesn't resolve `fromCallback` promise in case of message handling success.