### PR TITLE
Bump "serverless-offline" up to 5.0.1.

### DIFF
--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -20,7 +20,7 @@
     "aws-sdk": "^2.444.0",
     "figures": "^3.0.0",
     "lodash": "^4.17.11",
-    "serverless-offline": "^4.10.0"
+    "serverless-offline": "^5.0.1"
   },
   "keywords": [
     "sqs",


### PR DESCRIPTION
This supports the namespaced hapi components.