### PR TITLE
Fix: Environment variables absent when lambda function triggered through SQS

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -151,7 +151,7 @@ class ServerlessOfflineSQS {
       x.then(lambdaContext.succeed).catch(lambdaContext.fail);
     else if (x instanceof Error) lambdaContext.fail(x);
 
-    process.env = env;
+    // process.env = env;
   }
 
   async createQueueReadable(functionName, queueEvent) {


### PR DESCRIPTION
## Issue

Environment variables are not picked up when lambda is triggered from an SQS queue in AWS.

serverless.yml
```yml
environment: 
  - FOO: bar
```
handler.js
``` js
console.log(process.env.FOO)
```
Console
```bash
undefined
```

## Fix

During inspection of source code, it is found out that environment is set but it is reset to original state after executing lambda. On commenting out the reset part, the code runs successfully and environment is what it should be.

index.js
``` js
const {env} = process;
const functionEnv = assignAll([
  env,
  get('service.provider.environment', this),
  get('environment', __function)
]);
process.env = functionEnv;

// Heavylifting

process.env = env;
```