### PR TITLE
Fix: Configure AWS_REGION from serverless config

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -100,6 +100,7 @@ class ServerlessOfflineSQS {
     const {env} = process;
     const functionEnv = assignAll([
       env,
+      { AWS_REGION: this.service.provider.region },
       get('service.provider.environment', this),
       get('environment', __function)
     ]);


### PR DESCRIPTION
## Issue
The lambda function is missing AWS_REGION config when triggered though SQS in offline mode.

## Fix
Set AWS_REGION in environment.

index.js
```js
process.env = {
  ...process.env,
  { AWS_REGION: this.service.provider.region },
}
```