### PR TITLE
Add eventSourceARN to Dynamo stream records

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -106,7 +106,7 @@ class ServerlessOfflineDynamoDBStreams {
       cb(err, data);
     });
     const event = {
-      Records
+      Records: Records.map(record => Object.assign({}, record, {eventSourceARN: streamARN}))
     };
 
     const x = handler(event, lambdaContext, lambdaContext.done);


### PR DESCRIPTION
Fixes #77 by adding `eventSourceARN` to Dynamo stream records.

