### PR TITLE
chore: Fix failing dependency audit

### DIFF
--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -20,7 +20,10 @@
     "aws-sdk": "^2.444.0",
     "figures": "^3.0.0",
     "lodash": "^4.17.11",
-    "serverless-offline": "^4.10.0"
+    "serverless-offline": "^5.11.0"
+  },
+  "resolutions": {
+    "@hapi/subtext": ">=6.1.2"
   },
   "keywords": [
     "sqs",


### PR DESCRIPTION
This PR fixes failing dependency audit for `serverless-offline-sqs`:

- Fix [NPM advisory 1168](https://www.npmjs.com/advisories/1168) by upgrading `serverless-offline` to version 5, which replaces `subtext` with `@hapi/subtext`
- Fix [NPM advisory 1165](https://www.npmjs.com/advisories/1165) by resolving `@hapi/subtext` to `>=6.1.2`

