### PR TITLE
Add package name to global package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "serverless-plugins",
   "private": true,
   "scripts": {
     "postinstall": "lerna bootstrap",


### PR DESCRIPTION
`name` field to be required field when using with npm new version.
This is main reason of Travis CI error, the CI has been crashed by `npm ci` command.
Detail:
`npm-lifecycle/index.js`  


```
function _incorrectWorkingDirectory (wd, pkg) {
  return wd.lastIndexOf(pkg.name) !== wd.length - pkg.name.length
}
```
