### PR TITLE
MessageAttributes properties in camelCase

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -137,7 +137,18 @@ class ServerlessOfflineSQS {
           receiptHandle,
           body,
           attributes,
-          messageAttributes,
+          messageAttributes: Object.keys(messageAttributes).reduce(
+            (prevAtt, attributeName) =>
+              Object.assign(prevAtt, {
+                [attributeName]: Object.keys(messageAttributes).reduce((prev, key) => {
+                  const lowerAttributeName = `${key.slice(0, 1).toLowerCase()}${key.slice(1)}`;
+                  return Object.assign(prev, {
+                    [lowerAttributeName]: messageAttributes[attributeName][key]
+                  });
+                }, {})
+              }),
+            {}
+          ),
           md5OfBody,
           eventSource: 'aws:sqs',
           eventSourceARN: queueEvent.arn,


### PR DESCRIPTION
Hey,

All properties of MessageAttributes need to have their first letter in lowercase.

```
messageAttributes:  {
            jobId:  {
                 stringValue: '12EBDH2B2', /* vs StringValue */
                 stringListValues: [Array], /* vs StringListValues */
                 binaryListValues: [Array], /* vs BinaryListValues */
                 dataType: 'String' /* vs DataType */
            }
}
```

Here is a fix.