### PR TITLE
doc says tableName, code says streamName

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -181,7 +181,7 @@ class ServerlessOfflineDynamoDBStreams {
     if (typeof tableEvent === 'string' && startsWith('arn:aws:dynamodb', tableEvent))
       return extractTableNameFromARN(tableEvent);
     if (typeof tableEvent.arn === 'string') return extractTableNameFromARN(tableEvent.arn);
-    if (typeof tableEvent.streamName === 'string') return tableEvent.streamName;
+    if (typeof tableEvent.tableName === 'string') return tableEvent.tableName;
 
     if (tableEvent.arn['Fn::GetAtt']) {
       const [ResourceName] = tableEvent.arn['Fn::GetAtt'];


### PR DESCRIPTION
The readme suggests the arn can be derived from the table name if you provide the `tableName` key, however this doesnt actually work at present as the code references the key `streamName` i have updated the code to reference `tableName` as per the documentation. 

This seemed like the best way round to resolve the issue rather than changing the documentation as it is face the table name that is required. 

Thanks, Ed
