### PR TITLE
feat(offline-dynamodb-streams): table does not have streams error

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -136,6 +136,9 @@ class ServerlessOfflineDynamoDBStreams {
       )
     ).then(get('Table.LatestStreamArn'));
 
+    if (!streamARN) {
+      throw new Error(`Table ${tableName} does not have streams`);
+    }
     this.serverless.cli.log(`${streamARN}`);
 
     const {


### PR DESCRIPTION
Currently if a table without streams is provided to `serverless-offline-dynamodb-streams`, it crashes with `MissingRequiredParameter: Missing required key 'StreamArn' in params`. This PR adds a more descriptive error.