### PR TITLE
feat(offline-dynamodb-streams): log function errors to console

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -100,8 +100,9 @@ class ServerlessOfflineDynamoDBStreams {
     const handler = functionHelper.createHandler(funOptions, this.getConfig());
 
     const lambdaContext = new LambdaContext(__function, this.service.provider, (err, data) => {
+      const output = data ? JSON.stringify(data) : err && err.stack;
       this.serverless.cli.log(
-        `[${err ? figures.cross : figures.tick}] ${functionName} ${JSON.stringify(data) || ''}`
+        `[${err ? figures.cross : figures.tick}] ${functionName} ${output || ''}`
       );
       cb(err, data);
     });


### PR DESCRIPTION
Currently if lambda function fails with error its result gets logged as
```
Serverless: [✖] DynamoDB_To_ES 
```
This PR adds error output after `DynamoDB_To_ES`.