### PR TITLE
Bug : Environment variables not available.

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -161,8 +161,6 @@ class ServerlessOfflineSQS {
     if (x && typeof x.then === 'function' && typeof x.catch === 'function')
       x.then(lambdaContext.succeed).catch(lambdaContext.fail);
     else if (x instanceof Error) lambdaContext.fail(x);
-
-    process.env = env;
   }
 
   async createQueueReadable(functionName, queueEvent) {


### PR DESCRIPTION
Removes unnecessary overwrite of `process.env` at end of function which results in a bug where environment variables are not available in the SQS runtime.