### PR TITLE
fix(serverless-offline-sqs) hostname resolved to 127.0.0.1

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -208,7 +208,9 @@ class ServerlessOfflineSQS {
       await fromCallback(cb => client.createQueue(params, cb));
     }
 
-    const {QueueUrl} = await fromCallback(cb => client.getQueueUrl({QueueName}, cb));
+    let {QueueUrl} = await fromCallback(cb => client.getQueueUrl({QueueName}, cb));
+    const endpointWithoutHost = QueueUrl.replace(/^[a-z]{4,5}\:\/{2}[a-z]{1,}\:[0-9]{1,4}.(.*)/, '$1');
+    QueueUrl = `${this.getConfig().endpoint}/${endpointWithoutHost}`;
 
     const next = async () => {
       const {Messages} = await fromCallback(cb =>

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -209,7 +209,8 @@ class ServerlessOfflineSQS {
     }
 
     let {QueueUrl} = await fromCallback(cb => client.getQueueUrl({QueueName}, cb));
-    const endpointWithoutHost = QueueUrl.replace(/^[a-z]{4,5}\:\/{2}[a-z]{1,}\:[0-9]{1,4}.(.*)/, '$1');
+
+    const endpointWithoutHost = QueueUrl.replace(/^[a-z]{4,5}:\/{2}[a-z]{1,}:\d{1,4}.(.*)/, '$1');
     QueueUrl = `${this.getConfig().endpoint}/${endpointWithoutHost}`;
 
     const next = async () => {


### PR DESCRIPTION
I came across an old issue: #33 
The same issue happened to me.

It was resolved however with the wrong answer. In his case (like mine) he ran serverless inside a docker too. Which then connects to the elasticMQ docker through the docker network.

The `client.getQueueUrl` returns `http://localhost:9324` because it doesn't know it's own ip. Therefore it will try to listen to messages on `https://localhost:9324/queue/<name>` for new messages and throw the  `Error: connect ECONNREFUSED 127.0.0.1:9324`

In this fix I simply replace the hostname of the returned queueUrl with the endpoint configured in the config. This should resolve most issues when it comes to offline handling of messages.

A better solution is welcome (: 