### PR TITLE
Add "enabled" flag for SQS Offline

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -92,6 +92,7 @@ You could use [ElasticMQ](https://github.com/adamw/elasticmq) with the following
 ```yml
 custom:
   serverless-offline-sqs:
+    enabled: true                     # if is not set, true by default
     autoCreate: true                 # create queue if not exists
     apiVersion: '2012-11-05'
     endpoint: http://0.0.0.0:9324

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -44,19 +44,25 @@ const extractQueueNameFromARN = arn => {
 
 class ServerlessOfflineSQS {
   constructor(serverless, options) {
-    this.serverless = serverless;
-    this.service = serverless.service;
-    this.options = options;
+    const isEnabled = getOr(true, 'enabled', options);
 
-    this.commands = {};
+    if (isEnabled) {
+      this.serverless = serverless;
+      this.service = serverless.service;
+      this.options = options;
 
-    this.hooks = {
-      'before:offline:start': this.offlineStartInit.bind(this),
-      'before:offline:start:init': this.offlineStartInit.bind(this),
-      'before:offline:start:end': this.offlineStartEnd.bind(this)
-    };
+      this.commands = {};
 
-    this.streams = [];
+      this.hooks = {
+        'before:offline:start': this.offlineStartInit.bind(this),
+        'before:offline:start:init': this.offlineStartInit.bind(this),
+        'before:offline:start:end': this.offlineStartEnd.bind(this)
+      };
+
+      this.streams = [];
+    } else {
+      serverless.cli.log('WARN Serverless Offline SQS is Disabled');
+    }
   }
 
   getConfig() {


### PR DESCRIPTION
We had some cases that we wanted to do isolated functional tests but SQS was always required by it. With this flag, you can disable SQS offline if you need to run certain modules of your Serverless offline application in isolation.