### PR TITLE
Reference service during runtime instead of storing in constructor

### DIFF
--- a/tests/serverless-plugins-integration/package.json
+++ b/tests/serverless-plugins-integration/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start:kinesis": "sls --config serverless.kinesis.yml offline",
     "start:sqs": "sls --config serverless.sqs.yml offline",
-    "start:dynamodb-streams": "sls --config serverless.dynamodb-streams.yml offline",
+    "start:dynamodb-streams": "sls --config serverless.dynamodb-stream.yml offline",
     "test": "npm run test:sqs && npm run test:sqs:autocreate && npm run test:kinesis && npm run test:dynamodb-streams",
     "setup-service": "../../scripts/clean-start.sh",
     "pretest:dynamodb-streams": "npm run -s setup-service dynamodb",


### PR DESCRIPTION
There is a slight weirdness with serverless, in that during the init hook, `this.serverless.service` isn't always compiled when refering to resources that might live in a different file. This means the resolution of the resource fails for getting streams. For example:

severless.yml
```
service:
  name: service

plugins:
  - serverless-offline-dynamodb-streams
  - serverless-offline

custom:
  serverless-offline:
    port: 3001
  serverless-offline-dynamodb-streams:
    apiVersion: '2013-12-02'
    endpoint: http://0.0.0.0:8000
    region: us-east-1
    accessKeyId: root
    secretAccessKey: root
    skipCacheInvalidation: false
    readInterval: 500

provider:
  name: aws
  runtime: nodejs12.x
  region: eu-central-1

functions:
  hello:
    handler: src/hello.handler
    events:
      - stream:
          type: dynamodb
          arn:
            Fn::GetAtt:
              - MyTable
              - Arn

resources:
  - ${file(resources/dynamodb.yml)}
```

resources.yml
```
Resources:
  MyTable:
    Type: "AWS::DynamoDB::Table"
    DeletionPolicy: Retain
    Properties:
      TableName: MyTable
      AttributeDefinitions:
        -
          AttributeName: id
          AttributeType: S
      KeySchema:
        -
          AttributeName: id
          KeyType: HASH
      StreamSpecification:
        StreamViewType: NEW_IMAGE
```

This PR changes the references to a function which gets the latest version from the service.

This is also referenced in the serverless bug here: https://github.com/serverless/serverless/pull/3911