### PR TITLE
Don't block on start

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -77,8 +77,7 @@ class ServerlessOfflineDynamodbStreams {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready().then(() => this.end());
   }
 
   async end(skipExit) {


### PR DESCRIPTION
Not sure if this is expected or I'm doing this wrong, but even in the correct order as mentioned in the docs - webpack, streams, offline, this was still blocking the thread and stopping offline from starting...
"serverless-offline": "^6.4.0",
"serverless-offline-dynamodb-streams": "^4.0.1",
"serverless-webpack": "^5.3.2",