### PR TITLE
Avoid waiting for termination signal upon start-up

### DIFF
--- a/packages/serverless-offline-kinesis/src/index.js
+++ b/packages/serverless-offline-kinesis/src/index.js
@@ -75,7 +75,7 @@ class ServerlessOfflineKinesis {
 
   async _startWithExplicitEnd() {
     await this.start();
-    this.ready().then(this.end)
+    this.ready().then(this.end).catch(() => null);
   }
 
   async end(skipExit) {

--- a/packages/serverless-offline-kinesis/src/index.js
+++ b/packages/serverless-offline-kinesis/src/index.js
@@ -75,8 +75,7 @@ class ServerlessOfflineKinesis {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready().then(this.end)
   }
 
   async end(skipExit) {


### PR DESCRIPTION
With the following plugin order in serverless.yml, we currently get stuck at the start-up page:
```yml
  - serverless-plugin-typescript
  - serverless-offline-kinesis
  - serverless-offline
```

package.json:

    "serverless-offline": "^6.4.0",
    "serverless-offline-kinesis": "^4.0.1",
    "serverless-plugin-typescript": "^1.1.7"