### PR TITLE
Avoid waiting for termination signal upon start-up

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/index.js
+++ b/packages/serverless-offline-dynamodb-streams/src/index.js
@@ -77,8 +77,9 @@ class ServerlessOfflineDynamodbStreams {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready()
+      .then(this.end)
+      .catch(() => null);
   }
 
   async end(skipExit) {

--- a/packages/serverless-offline-kinesis/src/index.js
+++ b/packages/serverless-offline-kinesis/src/index.js
@@ -75,8 +75,9 @@ class ServerlessOfflineKinesis {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready()
+      .then(this.end)
+      .catch(() => null);
   }
 
   async end(skipExit) {

--- a/packages/serverless-offline-s3/src/index.js
+++ b/packages/serverless-offline-s3/src/index.js
@@ -76,8 +76,9 @@ class ServerlessOfflineS3 {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready()
+      .then(this.end)
+      .catch(() => null);
   }
 
   async end(skipExit) {

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -91,8 +91,9 @@ class ServerlessOfflineSQS {
 
   async _startWithExplicitEnd() {
     await this.start();
-    await this.ready();
-    this.end();
+    this.ready()
+      .then(this.end)
+      .catch(() => null);
   }
 
   async end(skipExit) {


### PR DESCRIPTION
With the following plugin order in serverless.yml, we currently get stuck at the start-up page:

  - serverless-plugin-typescript
  - serverless-offline-kinesis
  - serverless-offline
package.json:

"serverless-offline": "^6.4.0",
"serverless-offline-kinesis": "^4.0.1",
"serverless-plugin-typescript": "^1.1.7"