### PR TITLE
fix(DynamodbStreams): add option for streams endpoint

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/README.md
+++ b/packages/serverless-offline-dynamodb-streams/README.md
@@ -75,3 +75,20 @@ functions:
           type: dynamodb
           tableName: myTable
 ```
+
+### Localstack
+
+You could use [localstack](https://github.com/localstack/localstack) with the following configuration:
+
+```yml
+custom:
+  serverless-offline-dynamodb-streams:
+    apiVersion: '2013-12-02'
+    endpoint: http://0.0.0.0:4569
+    endpointStreams: http://0.0.0.0:4570
+    region: eu-west-1
+    accessKeyId: root
+    secretAccessKey: root
+    skipCacheInvalidation: false
+    readInterval: 500
+```

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
@@ -15,8 +15,10 @@ class DynamodbStreams {
 
     this.lambda = lambda;
     this.options = options;
-
     this.client = new DynamodbClient(this.options);
+    if (this.options.endpointStreams) {
+      this.options.endpoint = this.options.endpointStreams;
+    }
     this.streamsClient = new DynamodbStreamsClient(this.options);
 
     this.readables = [];


### PR DESCRIPTION
When using Localstack (https://github.com/localstack/localstack), DynamoDB and DynamoDB Streams are not using the same port. This PR adds the option `endpointStreams` to customise the endpoint.