### PR TITLE
fix: remove undefined reference to `this.region`

### DIFF
--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -81,7 +81,7 @@ class SQS {
         try {
           const lambdaFunction = this.lambda.get(functionKey);
 
-          const event = new SQSEvent(Messages, this.region, arn);
+          const event = new SQSEvent(Messages, this.options.region, arn);
           lambdaFunction.setEvent(event);
 
           await lambdaFunction.runHandler();


### PR DESCRIPTION
In `packages/serverless-offline-sqs/src/sqs.js`, there is an undefined reference to `this.region` that causes the `awsRegion` parameter to not be passed to lambda invocations. 

For context, I am using a [parsing library](https://github.com/awslabs/aws-lambda-powertools-python) that considers awsRegion to be a required field.