### PR TITLE
start non-SQS lambdas, default to localhost

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -61,9 +61,11 @@ class ServerlessOfflineSQS {
 
     const {sqsEvents, lambdas} = this._getEvents();
 
-    this._createLambda(lambdas);
-
     const eventModules = [];
+
+    if(lambdas.length > 0){
+      eventModules.push(this._createLambda(lambdas));
+    }
 
     if (sqsEvents.length > 0) {
       eventModules.push(this._createSqs(sqsEvents));
@@ -119,10 +121,17 @@ class ServerlessOfflineSQS {
     }
   }
 
-  _createLambda(lambdas) {
+  async _createLambda(events, skipStart) {
+    if(!this.options.host){
+      this.options.host = 'localhost';
+    }
     this.lambda = new Lambda(this.serverless, this.options);
 
-    this.lambda.create(lambdas);
+    await this.lambda.create(events);
+
+    if (!skipStart) {
+      await this.lambda.start();
+    }
   }
 
   async _createSqs(events, skipStart) {


### PR DESCRIPTION
My team was unable to use non-SQS functions alongside the SQS functions we used this plugin for in our serverless configuration. This seems like it was just a bug.