### PR TITLE
Adds creation of dlq from resources

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -74,6 +74,12 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: MyFourthQueue
+      RedrivePolicy:
+        deadLetterTargetArn: # Support only this format for autoCreate
+          Fn::GetAtt:
+          - MyFourthQueueDlq
+          - Arn
+        maxReceiveCount: 6
 
     MyFifthQueue: # Support for Fifo queue creation starts from 3.1 only
       Type: AWS::SQS::Queue
@@ -81,6 +87,11 @@ resources:
         QueueName: MyFifthQueue.fifo
         FifoQueue: true
         ContentBasedDeduplication: true
+
+    MyFourthQueueDlq:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: MyFourthQueueDlq
 ```
 
 ### SQS

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -130,6 +130,9 @@ class ServerlessOfflineSQS {
 
     this.sqs = new SQS(this.lambda, resources, this.options);
 
+    await this.sqs.createDlq(
+      get(['service', 'resources', 'Resources'], this.serverless));
+
     await this.sqs.create(events);
 
     if (!skipStart) {

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -130,8 +130,7 @@ class ServerlessOfflineSQS {
 
     this.sqs = new SQS(this.lambda, resources, this.options);
 
-    await this.sqs.createDlq(
-      get(['service', 'resources', 'Resources'], this.serverless));
+    await this.sqs.createDlq(get(['service', 'resources', 'Resources'], this.serverless));
 
     await this.sqs.create(events);
 

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -1,7 +1,18 @@
 const {default: PQueue} = require('p-queue');
 const SQSClient = require('aws-sdk/clients/sqs');
-// eslint-disable-next-line no-shadow
-const {pipe, get, values, matches, find, mapValues, isPlainObject, toString, map, compact} = require('lodash/fp');
+const {
+  pipe,
+  get,
+  values,
+  matches,
+  find,
+  mapValues,
+  isPlainObject,
+  // eslint-disable-next-line no-shadow
+  toString,
+  map,
+  compact
+} = require('lodash/fp');
 const {logWarning} = require('serverless-offline/dist/serverlessLog');
 const SQSEventDefinition = require('./sqs-event-definition');
 const SQSEvent = require('./sqs-event');
@@ -53,26 +64,29 @@ class SQS {
   }
 
   _createDlq(resources) {
-    if (!this.options.autoCreate) return
+    if (!this.options.autoCreate) return;
     const dlqNames = this._getDlqNames(resources);
-    return Promise.all(dlqNames.map((queueName) => {
-      return this._createQueue({ queueName });
-    }))
+    return Promise.all(
+      dlqNames.map(queueName => {
+        return this._createQueue({queueName});
+      })
+    );
   }
 
+  // eslint-disable-next-line class-methods-use-this
   _getDlqNames(resources) {
     return pipe(
       values,
-      map((value) => {
-        const dlq = get(['Properties', 'RedrivePolicy', 'deadLetterTargetArn'], value)
-        if (!dlq) return
-        const [resourceName, attribute] = dlq["Fn::GetAtt"];
-        const type = get(["Type"], resources[resourceName]);
-        if (attribute !== "Arn") return;
-        if (type !== "AWS::SQS::Queue") return;
-        return get(["Properties", "QueueName"], resources[resourceName])
+      map(value => {
+        const dlq = get(['Properties', 'RedrivePolicy', 'deadLetterTargetArn'], value);
+        if (!dlq) return;
+        const [resourceName, attribute] = dlq['Fn::GetAtt'];
+        const type = get(['Type'], resources[resourceName]);
+        if (attribute !== 'Arn') return;
+        if (type !== 'AWS::SQS::Queue') return;
+        return get(['Properties', 'QueueName'], resources[resourceName]);
       }),
-      compact,
+      compact
     )(resources);
   }
 

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -1,7 +1,7 @@
 const {default: PQueue} = require('p-queue');
 const SQSClient = require('aws-sdk/clients/sqs');
 // eslint-disable-next-line no-shadow
-const {pipe, get, values, matches, find, mapValues, isPlainObject, toString} = require('lodash/fp');
+const {pipe, get, values, matches, find, mapValues, isPlainObject, toString, map, compact} = require('lodash/fp');
 const {logWarning} = require('serverless-offline/dist/serverlessLog');
 const SQSEventDefinition = require('./sqs-event-definition');
 const SQSEvent = require('./sqs-event');
@@ -30,6 +30,10 @@ class SQS {
     return Promise.all(events.map(({functionKey, sqs}) => this._create(functionKey, sqs)));
   }
 
+  createDlq(resources) {
+    return this._createDlq(resources);
+  }
+
   start() {
     this.queue.start();
   }
@@ -46,6 +50,30 @@ class SQS {
     );
 
     return this._sqsEvent(functionKey, sqsEvent);
+  }
+
+  _createDlq(resources) {
+    if (!this.options.autoCreate) return
+    const dlqNames = this._getDlqNames(resources);
+    return Promise.all(dlqNames.map((queueName) => {
+      return this._createQueue({ queueName });
+    }))
+  }
+
+  _getDlqNames(resources) {
+    return pipe(
+      values,
+      map((value) => {
+        const dlq = get(['Properties', 'RedrivePolicy', 'deadLetterTargetArn'], value)
+        if (!dlq) return
+        const [resourceName, attribute] = dlq["Fn::GetAtt"];
+        const type = get(["Type"], resources[resourceName]);
+        if (attribute !== "Arn") return;
+        if (type !== "AWS::SQS::Queue") return;
+        return get(["Properties", "QueueName"], resources[resourceName])
+      }),
+      compact,
+    )(resources);
   }
 
   async _getQueueUrl(queueName) {


### PR DESCRIPTION
It adds support for creation of dlq from resources, but only with one format :(

```yaml
      RedrivePolicy:
        deadLetterTargetArn: # Support only this format for autoCreate
          Fn::GetAtt:
          - MyFourthQueueDlq
          - Arn
        maxReceiveCount: 6
```

I think it solves #65 partially