### PR TITLE
chore(serverless-offline-sqs): allow passing queueName from config

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -99,4 +99,5 @@ custom:
     accessKeyId: root
     secretAccessKey: root
     skipCacheInvalidation: false
+    queueName: MyQueueNameOverride   # overrides queueName from event definition
 ```

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -39,6 +39,12 @@ class SQS {
   }
 
   _create(functionKey, rawSqsEventDefinition) {
+    const {queueName} = this.options;
+
+    if (queueName) {
+      rawSqsEventDefinition.queueName = queueName;
+    }
+
     const sqsEvent = new SQSEventDefinition(
       rawSqsEventDefinition,
       this.options.region,


### PR DESCRIPTION
Seems like this functionality was once supported ([see PR](https://github.com/CoorpAcademy/serverless-plugins/pull/6))

I've found that allowing `queueName` to be overridden via configuration can help address issues with other plugins (e.g. Lift - https://github.com/getlift/lift/issues/101)

Feedback welcomed!