### PR TITLE
fix: add ^12 to allowed serverless-offline peer dependencies

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -23,7 +23,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "serverless-offline": "^10.0.2 || ^11"
+    "serverless-offline": "^10.0.2 || ^11 || ^12"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",

--- a/packages/serverless-offline-kinesis/package.json
+++ b/packages/serverless-offline-kinesis/package.json
@@ -27,7 +27,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "serverless-offline": "^10.0.2 || ^11"
+    "serverless-offline": "^10.0.2 || ^11 || ^12"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",

--- a/packages/serverless-offline-s3/package.json
+++ b/packages/serverless-offline-s3/package.json
@@ -27,7 +27,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "serverless-offline": "^10.0.2 || ^11"
+    "serverless-offline": "^10.0.2 || ^11 || ^12"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",

--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -27,7 +27,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "serverless-offline": "^10.0.2 || ^11"
+    "serverless-offline": "^10.0.2 || ^11 || ^12"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",


### PR DESCRIPTION
serverless-offline has released a new [major version](https://github.com/dherault/serverless-offline/releases/tag/v12.0.0), this version adds support for application load balancer and shouldn't be breaking for other things.

This `PR` allows the peer dependency to be in the 12 range too.