### PR TITLE
Support an version of serverless-offline greater than 11

### DIFF
--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -27,7 +27,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "serverless-offline": "^10.0.2 || ^11 || ^12"
+    "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",


### PR DESCRIPTION
This should stop needing to commit an update for each new version