### PR TITLE
Respect the serverless.yml's enabled flag

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-event-definition.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-event-definition.js
@@ -34,7 +34,7 @@ class DynamodbStreamsEventDefinition {
       // No default
     }
 
-    this.enabled = isNil(enabled) ? true : enabled;
+    this.enabled = isNil(rawSqsEventDefinition.enabled) ? true : rawSqsEventDefinition.enabled;
 
     this.arn = `arn:aws:dynamodb:${region}:${accountId}:${tableName}`;
     this.tableName = tableName;

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-event-definition.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-event-definition.js
@@ -12,7 +12,6 @@ class DynamodbStreamsEventDefinition {
     this.maximumRetryAttempts = 10;
     this.startingPosition = 'LATEST';
 
-    let enabled;
     let tableName;
 
     switch ('string') {

--- a/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
+++ b/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
@@ -32,8 +32,9 @@ class KinesisEventDefinition {
       // No default
     }
 
-    this.enabled = isNil(rawKinesisEventDefinition.enabled) 
-      ? true : rawKinesisEventDefinition.enabled;
+    this.enabled = isNil(rawKinesisEventDefinition.enabled)
+      ? true
+      : rawKinesisEventDefinition.enabled;
 
     this.arn = `arn:aws:kinesis:${region}:${accountId}:${streamName}`;
     this.streamName = streamName;

--- a/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
+++ b/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
@@ -11,7 +11,6 @@ class KinesisEventDefinition {
     this.batchSize = 10;
     this.startingPosition = 'LATEST';
 
-    let enabled;
     let streamName;
 
     switch ('string') {
@@ -33,7 +32,8 @@ class KinesisEventDefinition {
       // No default
     }
 
-    this.enabled = isNil(rawKinesisEventDefinition.enabled) ? true : rawKinesisEventDefinition.enabled;
+    this.enabled = isNil(rawKinesisEventDefinition.enabled) 
+      ? true : rawKinesisEventDefinition.enabled;
 
     this.arn = `arn:aws:kinesis:${region}:${accountId}:${streamName}`;
     this.streamName = streamName;

--- a/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
+++ b/packages/serverless-offline-kinesis/src/kinesis-event-definition.js
@@ -33,7 +33,7 @@ class KinesisEventDefinition {
       // No default
     }
 
-    this.enabled = isNil(enabled) ? true : enabled;
+    this.enabled = isNil(rawKinesisEventDefinition.enabled) ? true : rawKinesisEventDefinition.enabled;
 
     this.arn = `arn:aws:kinesis:${region}:${accountId}:${streamName}`;
     this.streamName = streamName;

--- a/packages/serverless-offline-sqs/src/sqs-event-definition.js
+++ b/packages/serverless-offline-sqs/src/sqs-event-definition.js
@@ -7,7 +7,6 @@ const extractQueueNameFromARN = arn => {
 
 class SQSEventDefinition {
   constructor(rawSqsEventDefinition, region, accountId) {
-    let enabled;
     let queueName;
 
     switch ('string') {

--- a/packages/serverless-offline-sqs/src/sqs-event-definition.js
+++ b/packages/serverless-offline-sqs/src/sqs-event-definition.js
@@ -29,7 +29,7 @@ class SQSEventDefinition {
       // No default
     }
 
-    this.enabled = isNil(enabled) ? true : enabled;
+    this.enabled = isNil(rawSqsEventDefinition.enabled) ? true : rawSqsEventDefinition.enabled;
 
     this.arn = `arn:aws:sqs:${region}:${accountId}:${queueName}`;
     this.queueName = queueName;


### PR DESCRIPTION
If you set enabled: false in your serverless.yml, this ignores it and keeps the local one running.

So, respect the enabled flag in serverless.yml

```
functions:
  kinesisHandler:
    handler: .build/main.kinesisEventHandler
    timeout: 120
    events:
      - stream:
          type: kinesis
          arn: ...
          maximumRetryAttempts: 0 # Quick retry
          parallelizationFactor: 10
          maximumRecordAgeInSeconds: 360 # 5 minutes
          enabled: false <----- now respected, was ignored before
          startingPosition: TRIM_HORIZON
          functionResponseType: ReportBatchItemFailures
  
```