### PR TITLE
feat(serverless-offline-ssm-provider): revive plugin — resolve ${ssm:/path} from a local map offline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16116,6 +16116,10 @@
       "resolved": "packages/serverless-offline-sqs",
       "link": true
     },
+    "node_modules/serverless-offline-ssm-provider": {
+      "resolved": "packages/serverless-offline-ssm-provider",
+      "link": true
+    },
     "node_modules/serverless-offline/node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -19365,6 +19369,22 @@
         "serverless-offline": "^10.0.2 || >=11"
       }
     },
+    "packages/serverless-offline-ssm-provider": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "serverless-offline": "^13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "serverless-offline": "^10.0.2 || >=11"
+      }
+    },
     "tests/serverless-plugins-integration": {
       "name": "serverless-offline-plugins-integration",
       "version": "4.0.0",
@@ -19376,7 +19396,8 @@
         "serverless-offline": "^13",
         "serverless-offline-dynamodb-streams": "^7.0.0",
         "serverless-offline-kinesis": "^7.0.0",
-        "serverless-offline-sqs": "^8.0.0"
+        "serverless-offline-sqs": "^8.0.0",
+        "serverless-offline-ssm-provider": "^1.0.0"
       }
     }
   }

--- a/packages/serverless-offline-ssm-provider/LICENSE
+++ b/packages/serverless-offline-ssm-provider/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2019-2026 CoorpAcademy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</content>

--- a/packages/serverless-offline-ssm-provider/NOTICE
+++ b/packages/serverless-offline-ssm-provider/NOTICE
@@ -1,0 +1,6 @@
+serverless-offline-ssm-provider
+Copyright (c) 2019-2026 CoorpAcademy
+
+This product adapts the AWS request-interception approach from
+serverless-offline-ssm v6.2.0 (MIT License), Copyright (c) Jim Anders (janders223).
+https://github.com/janders223/serverless-offline-ssm

--- a/packages/serverless-offline-ssm-provider/README.md
+++ b/packages/serverless-offline-ssm-provider/README.md
@@ -1,3 +1,124 @@
 # serverless-offline-ssm-provider
 
-# This package is deprecated. Use the [`serverless-offline-ssm`](https://www.npmjs.com/package/serverless-offline-ssm)
+Resolve `${ssm:/path}` variables from a **local map** during your configured offline stages,
+with **zero AWS round-trips**. Real deploys (non-offline stages) are left completely untouched.
+
+This is a first-party, maintained replacement for
+[`janders223/serverless-offline-ssm`](https://github.com/janders223/serverless-offline-ssm).
+Migration is a one-line dependency swap — see [Migration](#migration-from-serverless-offline-ssm).
+
+## How it works
+
+During a configured offline stage the plugin monkeypatches the `aws` provider's `request` method
+and intercepts only `('SSM', 'getParameter', {Name})` calls. When the requested `Name` is found in
+your local map, it returns a synthetic `{Parameter: {Value, Type}}` response and the **built-in
+Serverless `ssm` resolver** does all the downstream `String` / `StringList` / `SecureString` /
+`~raw` / `~noDecrypt` handling for free. Every other AWS call (CloudFormation, S3, deploy, etc.) is
+passed straight through to the real provider.
+
+> Note: the plugin does **not** register a `configurationVariablesSources.ssm` source. Under an
+> `aws` provider the framework already reserves the `ssm` source name, and declaring it again throws
+> `DUPLICATE_VARIABLE_SOURCE_CONFIGURATION`. Patching the provider request is the supported mechanism
+> and keeps the existing `${ssm:...}` contract intact.
+
+## Installation
+
+```sh
+npm install --save-dev serverless-offline-ssm-provider
+```
+
+Add the plugin to your `serverless.yml` **before** `serverless-offline`:
+
+```yml
+plugins:
+  - serverless-offline-ssm-provider
+  - serverless-offline
+```
+
+## Configure (#105)
+
+Declare the offline stages and the local SSM map under `custom.serverless-offline-ssm`
+(note: the key is `serverless-offline-ssm`, **not** `-ssm-provider`):
+
+```yml
+custom:
+  serverless-offline-ssm:
+    stages:
+      - offline
+      - dev
+      - test
+    ssm:
+      /credentials/dev/bedrock-model-id: anthropic.claude-3            # -> String
+      /api/v1/some-flag: 'a,b,c'                                       # -> StringList
+      /credentials/dev/google-credentials: '{"type":"service_account"}' # -> SecureString (parsed)
+
+functions:
+  echo:
+    handler: handler.promise
+    environment:
+      MODEL: ${ssm:/credentials/dev/bedrock-model-id}
+```
+
+You can also override the stages from the CLI (parity with `serverless-offline-ssm`):
+
+```sh
+sls offline --ssmOfflineStages dev,test,offline
+```
+
+If neither `custom.serverless-offline-ssm.stages` nor `--ssmOfflineStages` is set, the plugin
+fails fast with a clear error.
+
+## Precedence (#152)
+
+The local map is an **override layer**, not a sandbox wall:
+
+| Situation                          | Resolution                          |
+| ---------------------------------- | ----------------------------------- |
+| offline stage + key **present**    | local map value (no AWS call)       |
+| offline stage + key **absent**     | falls through to **real AWS SSM**   |
+| non-offline stage (e.g. `prod`)    | never patched — real AWS for everything |
+
+Falling through on a miss means a typo'd path surfaces as a real SSM error instead of being
+silently nulled, matching real-deploy behavior.
+
+## Parameter types (#186)
+
+The synthetic response always carries a valid `Type`, so the built-in resolver never throws
+`Unexpected parameter type`. The `Type` is inferred from the map value:
+
+| Map value                                   | Inferred `Type` | Resolved as                         |
+| ------------------------------------------- | --------------- | ----------------------------------- |
+| plain scalar (`anthropic.claude-3`)         | `String`        | literal string                      |
+| array (`['a','b','c']`) or CSV (`'a,b,c'`)  | `StringList`    | array (built-in splits on `,`)      |
+| `{`-prefixed JSON string                    | `SecureString`  | parsed object (built-in `JSON.parse`) |
+
+The `~raw` and `~noDecrypt` modifiers (`${ssm:/p~raw}`) work out of the box — they are honored by
+the built-in resolver on the `Type`/`Value` the plugin provides.
+
+### Forcing a type (override)
+
+Inference is best-effort and explicitly overridable with a per-value `{value, type}` object — for
+example to keep a JSON-looking string as a literal `String`:
+
+```yml
+custom:
+  serverless-offline-ssm:
+    stages: [dev]
+    ssm:
+      /raw/json-literal:
+        value: '{"a":1}'
+        type: String   # keep it a literal string, do not JSON.parse
+```
+
+## Migration from `serverless-offline-ssm`
+
+1. Replace the dependency:
+
+   ```diff
+   - "serverless-offline-ssm": "^6.2.0"
+   + "serverless-offline-ssm-provider": "^1.0.0"
+   ```
+
+2. Add `serverless-offline-ssm-provider` to `plugins` **before** `serverless-offline`.
+3. Keep your existing `custom.serverless-offline-ssm` block **unchanged** — the config key and
+   `{stages, ssm}` shape are identical by design.

--- a/packages/serverless-offline-ssm-provider/package.json
+++ b/packages/serverless-offline-ssm-provider/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "serverless-offline-ssm-provider",
+  "version": "1.0.0",
+  "description": "Resolve SSM parameters locally for the configured offline stages of your Serverless project",
+  "main": "src",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:CoorpAcademy/serverless-plugins.git"
+  },
+  "bugs": {
+    "url": "https://github.com/CoorpAcademy/serverless-plugins/issues"
+  },
+  "homepage": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-ssm-provider#readme",
+  "files": [
+    "src/index.js",
+    "src/log.js",
+    "src/ssm.js"
+  ],
+  "author": "Adrien Becchis @AdrieanKhisbe",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "peerDependencies": {
+    "serverless-offline": "^10.0.2 || >=11"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "serverless-offline": "^13"
+  },
+  "keywords": [
+    "ssm",
+    "ssm-provider",
+    "serverless",
+    "serverless-offline",
+    "lambda"
+  ]
+}

--- a/packages/serverless-offline-ssm-provider/src/index.js
+++ b/packages/serverless-offline-ssm-provider/src/index.js
@@ -1,0 +1,57 @@
+const {get, isEmpty} = require('lodash/fp');
+
+const {normalizeLog} = require('./log');
+const {resolveParameter, shouldExecute} = require('./ssm');
+
+const CUSTOM_OPTION = 'serverless-offline-ssm';
+
+class ServerlessOfflineSsmProvider {
+  constructor(serverless, cliOptions, {log} = {}) {
+    this.serverless = serverless;
+    this.cliOptions = cliOptions || {};
+    this.log = normalizeLog(log);
+
+    const config = get(['service', 'custom', CUSTOM_OPTION], serverless) || {};
+
+    const stages = this.cliOptions.ssmOfflineStages
+      ? this.cliOptions.ssmOfflineStages.split(',')
+      : config.stages;
+
+    if (isEmpty(stages))
+      throw new Error(
+        'serverless-offline-ssm-provider: missing "custom.serverless-offline-ssm.stages"'
+      );
+
+    const stage = this.cliOptions.stage || get(['service', 'provider', 'stage'], serverless);
+    this.ssmMap = config.ssm || {};
+
+    if (shouldExecute(stages, stage)) this._patchAwsRequest();
+  }
+
+  _patchAwsRequest() {
+    const aws = this.serverless.getProvider && this.serverless.getProvider('aws');
+    if (!aws) return; // non-aws provider: no-op, never patch
+
+    const original = aws.request.bind(aws);
+
+    aws.request = (service, method, params, opts) => {
+      // Pass through everything that is not an SSM getParameter (CF/S3/deploy calls).
+      if (service !== 'SSM' || method !== 'getParameter')
+        return original(service, method, params, opts);
+
+      const hit = resolveParameter(this.ssmMap, params && params.Name);
+      // Offline-stage miss => fall through to real AWS SSM (local map is an override layer, #152).
+      if (!hit) return original(service, method, params, opts);
+
+      this.log.debug(`[ssm-provider] resolved ${params.Name} locally as ${hit.Type}`);
+      // #186: the synthetic Parameter MUST always carry a Type, or get-ssm.js throws.
+      // The built-in resolver `await`s this, so a resolved promise matches its contract.
+      return Promise.resolve({Parameter: {...params, Value: hit.Value, Type: hit.Type}});
+    };
+
+    this.serverless.setProvider('aws', aws);
+    this.log.notice('serverless-offline-ssm-provider: resolving ssm locally for offline stage');
+  }
+}
+
+module.exports = ServerlessOfflineSsmProvider;

--- a/packages/serverless-offline-ssm-provider/src/log.js
+++ b/packages/serverless-offline-ssm-provider/src/log.js
@@ -1,0 +1,13 @@
+const noop = () => {};
+
+const defaultLog = {
+  debug: noop,
+  info: console.log.bind(console),
+  notice: console.log.bind(console),
+  warning: console.warn.bind(console),
+  error: console.error.bind(console),
+  success: console.log.bind(console)
+};
+const normalizeLog = log => ({...defaultLog, ...log});
+
+module.exports = {defaultLog, normalizeLog};

--- a/packages/serverless-offline-ssm-provider/src/ssm.js
+++ b/packages/serverless-offline-ssm-provider/src/ssm.js
@@ -1,0 +1,40 @@
+const {has, isArray, isPlainObject, isString} = require('lodash/fp');
+
+// A '{'-prefixed string is treated as a JSON object (SecureString) candidate.
+const looksLikeJson = value => isString(value) && value.trim().startsWith('{');
+
+// inferType(value) -> 'String' | 'StringList' | 'SecureString'
+// Best-effort inference; the built-in resolver does the actual split/parse from the Type.
+const inferType = value => {
+  if (isArray(value)) return 'StringList';
+  if (looksLikeJson(value)) return 'SecureString';
+  if (isString(value) && value.includes(',')) return 'StringList';
+  return 'String';
+};
+
+// Coerce a map value to the raw string the built-in resolver expects.
+// Arrays are joined with ',' so the built-in's `.split(',')` reproduces the array.
+const toRawValue = value => (isArray(value) ? value.join(',') : value);
+
+// normalizeEntry(entry) -> {value: <string>, type}
+// entry is either a plain string/array, or an explicit {value, type} override object.
+const normalizeEntry = entry => {
+  if (isPlainObject(entry) && has('value', entry)) {
+    return {value: toRawValue(entry.value), type: entry.type || inferType(entry.value)};
+  }
+  return {value: toRawValue(entry), type: inferType(entry)};
+};
+
+// resolveParameter(ssmMap, name) -> {Value, Type} | undefined
+// undefined signals a miss: the caller falls through to real AWS SSM (#152).
+const resolveParameter = (ssmMap, name) => {
+  const map = ssmMap || {};
+  if (!has(name, map)) return undefined;
+  const {value, type} = normalizeEntry(map[name]);
+  return {Value: value, Type: type};
+};
+
+// shouldExecute(stages, stage) -> boolean
+const shouldExecute = (stages, stage) => isArray(stages) && stages.includes(stage);
+
+module.exports = {looksLikeJson, inferType, normalizeEntry, resolveParameter, shouldExecute};

--- a/packages/serverless-offline-ssm-provider/test/index.js
+++ b/packages/serverless-offline-ssm-provider/test/index.js
@@ -1,0 +1,314 @@
+const test = require('ava');
+
+const {defaultLog, normalizeLog} = require('../src/log');
+const {inferType, normalizeEntry, resolveParameter, shouldExecute} = require('../src/ssm');
+const ServerlessOfflineSsmProvider = require('../src');
+
+// ---------------------------------------------------------------------------
+// Constructor harness — a hand-rolled fake serverless + aws provider (no mocking lib)
+// ---------------------------------------------------------------------------
+
+const makeAws = () => {
+  const calls = [];
+  const original = (...args) => {
+    calls.push(args);
+    return Promise.resolve({__fromOriginal: true});
+  };
+  const aws = {request: original, __original: original};
+  return {aws, calls};
+};
+
+const makeServerless = ({custom, providerStage, aws} = {}) => {
+  let provider = aws;
+  return {
+    service: {
+      custom: custom ? {'serverless-offline-ssm': custom} : {},
+      provider: {stage: providerStage}
+    },
+    getProvider: name => (name === 'aws' ? provider : undefined),
+    setProvider: (name, value) => {
+      if (name === 'aws') provider = value;
+    }
+  };
+};
+
+// Factory wrapper so constructing the plugin is an expression (avoids `no-new` for side effects).
+const build = (serverless, cliOptions = {}, deps = {}) =>
+  new ServerlessOfflineSsmProvider(serverless, cliOptions, deps);
+
+// ---------------------------------------------------------------------------
+// shouldExecute — stage gating (TU #1)
+// ---------------------------------------------------------------------------
+
+test('shouldExecute is true when the stage is in the configured offline stages', t => {
+  t.true(shouldExecute(['offline', 'dev', 'test'], 'dev'));
+  t.true(shouldExecute(['offline', 'dev', 'test'], 'offline'));
+});
+
+test('shouldExecute is false for a non-offline stage', t => {
+  t.false(shouldExecute(['offline', 'dev', 'test'], 'prod'));
+});
+
+test('shouldExecute is false for empty/undefined/non-array stages', t => {
+  t.false(shouldExecute([], 'dev'));
+  t.false(shouldExecute(undefined, 'dev'));
+  t.false(shouldExecute(null, 'dev'));
+  t.false(shouldExecute('dev', 'dev'));
+});
+
+// ---------------------------------------------------------------------------
+// Constructor — stage gating + fail-fast (TU #1 cont.)
+// ---------------------------------------------------------------------------
+
+test('constructor throws when stages are missing', t => {
+  const {aws} = makeAws();
+  const serverless = makeServerless({custom: {ssm: {}}, providerStage: 'dev', aws});
+  const error = t.throws(() => new ServerlessOfflineSsmProvider(serverless, {}, {}));
+  t.regex(error.message, /missing "custom\.serverless-offline-ssm\.stages"/);
+});
+
+test('constructor does not patch aws.request for a non-offline stage', t => {
+  const {aws} = makeAws();
+  const original = aws.request;
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/x': 'y'}},
+    providerStage: 'prod',
+    aws
+  });
+  build(serverless, {}, {});
+  t.is(aws.request, original); // untouched
+});
+
+test('constructor patches aws.request for an offline stage', t => {
+  const {aws} = makeAws();
+  const original = aws.request;
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/x': 'y'}},
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {}, {});
+  t.not(aws.request, original); // replaced
+});
+
+test('constructor cliOptions.stage overrides provider.stage', t => {
+  const {aws} = makeAws();
+  const original = aws.request;
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {}},
+    providerStage: 'prod', // would NOT patch...
+    aws
+  });
+  build(serverless, {stage: 'dev'}, {}); // ...but cli stage does
+  t.not(aws.request, original);
+});
+
+test('constructor --ssmOfflineStages overrides the configured stages', t => {
+  const {aws} = makeAws();
+  const original = aws.request;
+  const serverless = makeServerless({
+    custom: {stages: ['prod'], ssm: {}}, // config would NOT include dev
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {ssmOfflineStages: 'dev,test'}, {});
+  t.not(aws.request, original);
+});
+
+test('constructor is a no-op (does not throw) when getProvider returns falsy', t => {
+  const serverless = {
+    service: {
+      custom: {'serverless-offline-ssm': {stages: ['dev'], ssm: {}}},
+      provider: {stage: 'dev'}
+    },
+    getProvider: () => undefined,
+    setProvider: () => {}
+  };
+  t.notThrows(() => new ServerlessOfflineSsmProvider(serverless, {}, {}));
+});
+
+// ---------------------------------------------------------------------------
+// resolveParameter — exact key / miss (TU #2, #3)
+// ---------------------------------------------------------------------------
+
+test('resolveParameter returns {Value, Type} for a mapped key', t => {
+  const map = {'/a/b': 'hello'};
+  t.deepEqual(resolveParameter(map, '/a/b'), {Value: 'hello', Type: 'String'});
+});
+
+test('resolveParameter returns undefined for an absent key and does not throw', t => {
+  t.is(resolveParameter({'/a/b': 'hello'}, '/nope'), undefined);
+  t.notThrows(() => resolveParameter({'/a/b': 'hello'}, '/nope'));
+  t.is(resolveParameter(undefined, '/nope'), undefined);
+  t.is(resolveParameter(null, '/nope'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// #186 — Type defaulting & inference (TU #4, #5, #6)
+// ---------------------------------------------------------------------------
+
+test('#186 inferType defaults to String for plain scalars', t => {
+  t.is(inferType('elevenlabs-api-key'), 'String');
+  t.is(inferType('/api/v1'), 'String');
+  t.is(inferType('anthropic.claude-3'), 'String');
+});
+
+test('#186 inferType detects StringList from CSV strings and arrays', t => {
+  t.is(inferType('a,b,c'), 'StringList');
+  t.is(inferType(['a', 'b', 'c']), 'StringList');
+});
+
+test('#186 normalizeEntry joins an array value so the built-in split reproduces it', t => {
+  const {value, type} = normalizeEntry(['a', 'b', 'c']);
+  t.is(value, 'a,b,c');
+  t.is(type, 'StringList');
+  t.deepEqual(value.split(','), ['a', 'b', 'c']); // mirrors get-ssm.js downstream
+});
+
+test('#186 inferType detects SecureString from a {-prefixed JSON string', t => {
+  t.is(inferType('{"type":"service_account"}'), 'SecureString');
+  t.is(inferType('   {"a":1}'), 'SecureString'); // leading whitespace tolerated
+});
+
+test('#186 a non-JSON secret stays a literal String', t => {
+  t.is(inferType('plain-secret'), 'String');
+});
+
+test('#186 SecureString JSON value round-trips through the built-in JSON.parse path', t => {
+  const {Value, Type} = resolveParameter({'/g': '{"type":"service_account"}'}, '/g');
+  t.is(Type, 'SecureString');
+  t.is(JSON.parse(Value).type, 'service_account');
+});
+
+// ---------------------------------------------------------------------------
+// {value, type} override — over-eager inference guard (TU #7)
+// ---------------------------------------------------------------------------
+
+test('normalizeEntry honors an explicit {value, type} override (force String)', t => {
+  t.deepEqual(normalizeEntry({value: '{"a":1}', type: 'String'}), {
+    value: '{"a":1}',
+    type: 'String'
+  });
+});
+
+test('normalizeEntry infers the type when an override object omits it', t => {
+  t.deepEqual(normalizeEntry({value: 'a,b,c'}), {value: 'a,b,c', type: 'StringList'});
+});
+
+test('normalizeEntry override joins an array value', t => {
+  t.deepEqual(normalizeEntry({value: ['a', 'b'], type: 'StringList'}), {
+    value: 'a,b',
+    type: 'StringList'
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patch passthrough / hit / fall-through (TU #8)
+// ---------------------------------------------------------------------------
+
+test('patched request returns synthetic Parameter for a mapped SSM getParameter (no AWS call)', async t => {
+  const {aws, calls} = makeAws();
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/it/plain': 'hello-world'}},
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {}, {});
+
+  const result = await aws.request('SSM', 'getParameter', {Name: '/it/plain'}, {});
+  t.deepEqual(result.Parameter.Value, 'hello-world');
+  t.is(result.Parameter.Type, 'String');
+  t.is(calls.length, 0); // original was NOT called
+});
+
+test('patched request falls through to original for a non-SSM call with identical args', async t => {
+  const {aws, calls} = makeAws();
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/it/plain': 'hello-world'}},
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {}, {});
+
+  await aws.request('CloudFormation', 'describeStacks', {StackName: 'x'}, {region: 'eu-west-1'});
+  t.is(calls.length, 1);
+  t.deepEqual(calls[0], [
+    'CloudFormation',
+    'describeStacks',
+    {StackName: 'x'},
+    {region: 'eu-west-1'}
+  ]);
+});
+
+test('patched request falls through for SSM methods other than getParameter', async t => {
+  const {aws, calls} = makeAws();
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/it/plain': 'hello-world'}},
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {}, {});
+
+  await aws.request('SSM', 'describeParameters', {}, {});
+  t.is(calls.length, 1);
+  t.deepEqual(calls[0], ['SSM', 'describeParameters', {}, {}]);
+});
+
+test('patched request falls through to real AWS for an unmapped SSM getParameter (#152)', async t => {
+  const {aws, calls} = makeAws();
+  const serverless = makeServerless({
+    custom: {stages: ['dev'], ssm: {'/it/plain': 'hello-world'}},
+    providerStage: 'dev',
+    aws
+  });
+  build(serverless, {}, {});
+
+  const params = {Name: '/not/in/map', WithDecryption: true};
+  const result = await aws.request('SSM', 'getParameter', params, {useCache: true});
+  t.is(calls.length, 1); // original WAS called
+  t.deepEqual(calls[0], ['SSM', 'getParameter', params, {useCache: true}]);
+  t.true(result.__fromOriginal);
+});
+
+// ---------------------------------------------------------------------------
+// normalizeLog suite — copied from the serverless-offline-sqs sibling (TU #9)
+// ---------------------------------------------------------------------------
+
+test('normalizeLog returns the console-backed default logger when given nothing', t => {
+  const log = normalizeLog();
+  t.is(typeof log.debug, 'function');
+  t.is(typeof log.info, 'function');
+  t.is(typeof log.notice, 'function');
+  t.is(typeof log.warning, 'function');
+  t.is(typeof log.error, 'function');
+  t.is(typeof log.success, 'function');
+});
+
+test('normalizeLog default debug is a silent noop returning undefined', t => {
+  t.is(normalizeLog().debug('quiet'), undefined);
+});
+
+test('normalizeLog handles null/undefined without throwing', t => {
+  t.notThrows(() => normalizeLog(null));
+  t.notThrows(() => normalizeLog(undefined));
+  t.deepEqual(Object.keys(normalizeLog(null)).sort(), Object.keys(defaultLog).sort());
+});
+
+test('normalizeLog overlays the injected logger over the defaults', t => {
+  const calls = [];
+  const injected = {notice: msg => calls.push(msg)};
+  const log = normalizeLog(injected);
+
+  log.notice('hello');
+  t.deepEqual(calls, ['hello']);
+  t.is(typeof log.warning, 'function');
+  t.is(log.error, defaultLog.error);
+});
+
+test('normalizeLog does not mutate the injected logger or defaults', t => {
+  const injected = {notice: () => {}};
+  const before = {...injected};
+  normalizeLog(injected);
+  t.deepEqual(injected, before);
+  t.is(defaultLog.debug, defaultLog.debug);
+});

--- a/tests/serverless-plugins-integration/package.json
+++ b/tests/serverless-plugins-integration/package.json
@@ -7,7 +7,8 @@
     "start:sqs": "sls offline start --config serverless.sqs.yml",
     "start:s3": "sls offline start --config serverless.s3.yml",
     "start:dynamodb-streams": "sls offline start --config serverless.dynamodb-streams.yml",
-    "test": "npm run test:dynamodb-streams && npm run test:kinesis && npm run test:s3 && npm run test:sqs && npm run test:sqs:autocreate",
+    "start:ssm": "sls print --config serverless.ssm.yml --stage offline",
+    "test": "npm run test:dynamodb-streams && npm run test:kinesis && npm run test:s3 && npm run test:sqs && npm run test:sqs:autocreate && npm run test:ssm",
     "setup-service": "../../scripts/clean-start.sh",
     "pretest:dynamodb-streams": "npm run -s setup-service dynamodb",
     "test:dynamodb-streams": "node test-dynamodb-streams",
@@ -18,7 +19,8 @@
     "pretest:sqs": "npm run -s setup-service sqs",
     "test:sqs": "node test-sqs",
     "pretest:sqs:autocreate": "npm run -s setup-service sqs",
-    "test:sqs:autocreate": "node test-sqs-autocreate"
+    "test:sqs:autocreate": "node test-sqs-autocreate",
+    "test:ssm": "node test-ssm"
   },
   "dependencies": {
     "aws-sdk": "^2.1234.0",
@@ -28,6 +30,7 @@
     "serverless-offline": "^13",
     "serverless-offline-dynamodb-streams": "^7.0.0",
     "serverless-offline-kinesis": "^7.0.0",
-    "serverless-offline-sqs": "^8.0.0"
+    "serverless-offline-sqs": "^8.0.0",
+    "serverless-offline-ssm-provider": "^1.0.0"
   }
 }

--- a/tests/serverless-plugins-integration/serverless.ssm.yml
+++ b/tests/serverless-plugins-integration/serverless.ssm.yml
@@ -1,0 +1,39 @@
+service: serverless-offline-ssm
+
+provider:
+  name: aws
+  region: eu-west-1
+  runtime: nodejs22.x
+  stage: offline
+  environment:
+    # Resolved at config-parse time from the local map (no AWS round-trip).
+    PLAIN: ${ssm:/it/plain}
+
+plugins:
+  # MUST be loaded before serverless-offline: the constructor patches aws.request
+  # before the framework resolves ${ssm:...} at config-parse time.
+  - ../../packages/serverless-offline-ssm-provider
+  - serverless-offline
+
+custom:
+  # NOTE: key is `serverless-offline-ssm` (matches the plugin's CUSTOM_OPTION),
+  # so a downstream service migrates by "swap the dependency, keep the config".
+  serverless-offline-ssm:
+    stages:
+      - offline
+    ssm:
+      /it/plain: hello-world # -> String
+      /it/list: 'a,b,c' # -> StringList (built-in splits on ',')
+      /it/json: '{"type":"service_account","ok":true}' # -> SecureString (built-in JSON.parses)
+  # A plain `custom` block accepts non-string values, so we can assert the
+  # StringList -> array and SecureString -> object transforms too.
+  resolved:
+    plain: ${ssm:/it/plain}
+    list: ${ssm:/it/list}
+    json: ${ssm:/it/json}
+
+functions:
+  echo:
+    handler: lambda/handler.promise
+    environment:
+      PLAIN: ${ssm:/it/plain}

--- a/tests/serverless-plugins-integration/test-ssm.js
+++ b/tests/serverless-plugins-integration/test-ssm.js
@@ -1,0 +1,148 @@
+const {spawnSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// SSM variable resolution happens at config-parse time, BEFORE `serverless-offline` starts and
+// with no lambda events — so the event-driven `runOfflineTest` harness does not apply here.
+// We drive `sls print` (osls) directly and assert on its rendered config.
+//
+// "No AWS call was made" is proven structurally, not by mocking the SDK:
+//   1. We run under a HOSTILE environment — no credentials, EC2 instance-metadata disabled,
+//      shared-credentials/config files pointed at /dev/null. Any real SSM `getParameter` would
+//      fail with "AWS provider credentials not found".
+//   2. The MAIN config (all keys present in the local map) resolves cleanly under that env =>
+//      the values came from the local map, not AWS.
+//   3. A CONTROL config referencing a key ABSENT from the map is run under the SAME env and MUST
+//      fail with the AWS-credentials error — proving the no-AWS guard is real, not vacuous (the
+//      plugin genuinely falls through to AWS on a miss; we are not silently nulling everything).
+
+const SLS = path.join(__dirname, '..', '..', 'node_modules', 'serverless', 'bin', 'serverless.js');
+const STAGE = 'offline';
+
+// Strip every AWS credential/region discovery channel so a real getParameter cannot succeed.
+const HOSTILE_ENV = {
+  ...process.env,
+  AWS_ACCESS_KEY_ID: '',
+  AWS_SECRET_ACCESS_KEY: '',
+  AWS_SESSION_TOKEN: '',
+  AWS_PROFILE: '',
+  AWS_SDK_LOAD_CONFIG: '0',
+  AWS_EC2_METADATA_DISABLED: 'true',
+  AWS_SHARED_CREDENTIALS_FILE: '/dev/null',
+  AWS_CONFIG_FILE: '/dev/null'
+};
+delete HOSTILE_ENV.AWS_ACCESS_KEY_ID;
+delete HOSTILE_ENV.AWS_SECRET_ACCESS_KEY;
+delete HOSTILE_ENV.AWS_SESSION_TOKEN;
+delete HOSTILE_ENV.AWS_PROFILE;
+
+const slsPrint = config => {
+  const {stdout, stderr, status, error} = spawnSync(
+    process.execPath,
+    [SLS, 'print', '--config', config, '--stage', STAGE],
+    {cwd: __dirname, env: HOSTILE_ENV, encoding: 'utf8'}
+  );
+  if (error) throw error;
+  return {out: `${stdout || ''}${stderr || ''}`, status};
+};
+
+const failures = [];
+const check = (label, condition) => {
+  if (condition) console.log(`  ok   ${label}`);
+  else {
+    console.error(`  FAIL ${label}`);
+    failures.push(label);
+  }
+};
+
+// --- 1. MAIN run: every key is in the local map; must resolve under the hostile env ----------
+console.log('[test-ssm] MAIN run (serverless.ssm.yml) under no-AWS env');
+const main = slsPrint('serverless.ssm.yml');
+
+// Resolution must NOT have errored / reached AWS / collided with the built-in source name.
+check('no "Cannot resolve variable"', !/Cannot resolve variable/.test(main.out));
+check(
+  'no AWS credentials error (=> no AWS call made)',
+  !/credentials not found|AWS_CREDENTIALS_NOT_FOUND/.test(main.out)
+);
+check(
+  'no DUPLICATE_VARIABLE_SOURCE_CONFIGURATION',
+  !/DUPLICATE_VARIABLE_SOURCE_CONFIGURATION/.test(main.out)
+);
+check('no "Unexpected parameter type"', !/Unexpected parameter type/.test(main.out));
+check(
+  'plugin patched for offline stage (notice printed)',
+  /resolving ssm locally for offline stage/.test(main.out)
+);
+
+// String: ssm:/it/plain -> the local literal, in provider.environment AND function.environment.
+check('String ssm /it/plain -> "hello-world"', /PLAIN:\s*hello-world/.test(main.out));
+check('String resolved in custom.resolved.plain', /plain:\s*hello-world/.test(main.out));
+
+// StringList: ssm:/it/list -> array (built-in split on ',').
+check(
+  'StringList ssm /it/list -> [a, b, c]',
+  /list:\s*\n\s*-\s*a\s*\n\s*-\s*b\s*\n\s*-\s*c/.test(main.out)
+);
+
+// SecureString: ssm:/it/json -> parsed object (built-in JSON.parse).
+check(
+  'SecureString ssm /it/json -> object {type: service_account, ok: true}',
+  /json:\s*\n\s*type:\s*service_account\s*\n\s*ok:\s*true/.test(main.out)
+);
+
+// --- 2. CONTROL run: a key ABSENT from the map MUST fall through to AWS and fail (no creds) ----
+// This makes the "no AWS call" assertion non-vacuous: it proves the env truly blocks AWS, so the
+// MAIN run succeeding can only mean the values came from the local map.
+console.log('[test-ssm] CONTROL run (unmapped key) under the SAME no-AWS env');
+// The control config must live in __dirname so its relative plugin path (`../../packages/...`)
+// resolves exactly like the main config; a unique name avoids colliding with the suite.
+const controlName = `serverless.ssm.control.${process.pid}.yml`;
+const controlYml = path.join(__dirname, controlName);
+fs.writeFileSync(
+  controlYml,
+  [
+    'service: ssm-control',
+    'provider:',
+    '  name: aws',
+    '  region: eu-west-1',
+    '  runtime: nodejs22.x',
+    '  stage: offline',
+    'plugins:',
+    '  - ../../packages/serverless-offline-ssm-provider',
+    'custom:',
+    '  serverless-offline-ssm:',
+    '    stages: [offline]',
+    '    ssm:',
+    '      /it/present: yes',
+    '  resolved:',
+    // The SSM reference is assembled so the literal token does not appear in source (keeps the
+    // `no-template-curly-in-string` lint clean); the written YAML still reads `${ssm:/...}`.
+    `    missing: \${ssm:/it/key-that-is-not-in-the-map}`,
+    ''
+  ].join('\n')
+);
+try {
+  const control = slsPrint(controlName);
+  check(
+    'unmapped key falls through to AWS and fails (no-creds env truly blocks AWS)',
+    /credentials not found|AWS_CREDENTIALS_NOT_FOUND|Cannot resolve variable at "custom\.resolved\.missing"/.test(
+      control.out
+    )
+  );
+} finally {
+  try {
+    fs.unlinkSync(controlYml);
+  } catch {
+    /* best-effort temp cleanup */
+  }
+}
+
+// --- verdict ---------------------------------------------------------------------------------
+if (failures.length === 0) {
+  console.log('[test-ssm] PASS: ssm:/... refs resolved from the local map under osls, no AWS call');
+  process.exit(0);
+} else {
+  console.error(`[test-ssm] FAIL: ${failures.length} assertion(s) failed: ${failures.join(' | ')}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Revives the deprecated **`serverless-offline-ssm-provider`** as a first-party, maintained replacement for [`janders223/serverless-offline-ssm`](https://github.com/janders223/serverless-offline-ssm). During a configured offline stage the plugin monkeypatches the `aws` provider's `request` and intercepts **only** `('SSM', 'getParameter', {Name})` calls. Mapped keys return a synthetic `{Parameter: {Value, Type}}` and the **built-in Serverless `ssm` resolver** does all the downstream `String` / `StringList` / `SecureString` / `~raw` / `~noDecrypt` handling. Every other AWS call — and every non-offline stage — is passed straight through untouched.

> It does **not** register a `configurationVariablesSources.ssm` source: under an `aws` provider the framework already reserves the `ssm` name, and re-declaring it throws `DUPLICATE_VARIABLE_SOURCE_CONFIGURATION`. Patching the provider request keeps the existing `${ssm:...}` contract intact.

## Issues fixed

- **#186** (@Phebonacci) — the synthetic `Parameter` now **always carries a valid `Type`** (inferred `String` / `StringList` / `SecureString`, with a per-value `{value, type}` override), so the built-in resolver never throws `Unexpected parameter type`.
- **#105** (@kevinswarner) — documented example config under `custom.serverless-offline-ssm` (`{stages, ssm}`), the `--ssmOfflineStages` CLI override, and fail-fast when stages are missing.
- **#152** (@bitsofinfo) — clarified precedence: the local map is an **override layer**, not a sandbox wall. An unmapped key on an offline stage **falls through to real AWS SSM**, so a typo'd path surfaces as a real error instead of being silently nulled.

Fixes #186
Fixes #105
Fixes #152

## Implementation

- Pure, exported helpers — `resolveParameter` / `inferType` / `normalizeEntry` / `shouldExecute` — unit-tested directly (house style).
- `{log}` 3rd-arg injection via `normalizeLog`; lodash/fp; immutable.
- `NOTICE` credits the upstream MIT request-interception approach.

## Testing

- **29 AVA unit tests** green (`npx ava packages/serverless-offline-ssm-provider/test/index.js`), `eslint .` clean.
- **Integration test** (`test:ssm`, wired into the suite) drives `sls print` under **osls** with a hostile no-credentials env, plus a **non-vacuous control** (an unmapped key under the same env *must* fail with the AWS-credentials error) — proving the resolved values came from the local map and **no AWS call was made**.
- `package-lock.json` regenerated for the new workspace package.
- Validated against a real consumer (TLS) config: all its `${ssm:/credentials/...}` paths resolve locally, the JSON SecureString round-trips to an object, and Lambda env vars resolve — with the #186 Type fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)