### PR TITLE
fix(serverless-offline-sqs): default idle-cleanup time to prevent ~50% idle CPU (#158)

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -25,6 +25,14 @@ const defaultOptions = {
   startingPosition: 'TRIM_HORIZON',
   autoCreate: false,
 
+  // #158 (raymond-w-ko): serverless-offline's LambdaFunctionPool schedules its idle-cleanup timer
+  // as setTimeout(fn, options.<idleOption> * 1000). The plugin builds its own pool options, so when
+  // the option is missing the product is NaN and the timer busy-loops at ~50% CPU on idle. The key
+  // was renamed across serverless-offline versions (functionCleanupIdleTimeSeconds <= v12,
+  // terminateIdleLambdaTime >= v13); default both to serverless-offline's own default (60s).
+  functionCleanupIdleTimeSeconds: 60,
+  terminateIdleLambdaTime: 60,
+
   accountId: '000000000000'
 };
 
@@ -231,3 +239,4 @@ class ServerlessOfflineSQS {
 }
 
 module.exports = ServerlessOfflineSQS;
+module.exports.defaultOptions = defaultOptions;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -6,6 +6,7 @@ const {defaultLog, normalizeLog} = require('../src/log');
 const {toDeleteEntries, resolveQueueName} = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
+const {defaultOptions} = require('../src');
 
 // ---------------------------------------------------------------------------
 // normalizeLog
@@ -207,4 +208,25 @@ test('src/sqs.js builds SQSEvent with this.options.region, not this.region (#166
   const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'sqs.js'), 'utf8');
   t.true(source.includes('this.options.region'));
   t.false(/new SQSEvent\(messages, this\.region\b/.test(source));
+});
+
+// ---------------------------------------------------------------------------
+// defaultOptions — idle-CPU guard (#158 raymond-w-ko)
+// ---------------------------------------------------------------------------
+
+test('#158 defaultOptions sets a finite idle-cleanup time so the pool timer is not NaN', t => {
+  // serverless-offline's LambdaFunctionPool schedules its idle-cleanup timer as
+  // setTimeout(fn, options.<idleOption> * 1000). When the option is absent the product is NaN,
+  // which busy-loops the timer at ~50% CPU on idle. The option was renamed across versions:
+  //   <= v12: functionCleanupIdleTimeSeconds   >= v13: terminateIdleLambdaTime
+  // so both must be a finite number for setTimeout(fn, x * 1000) to be valid.
+  t.true(Number.isFinite(defaultOptions.terminateIdleLambdaTime));
+  t.true(Number.isFinite(defaultOptions.functionCleanupIdleTimeSeconds));
+  t.false(Number.isNaN(defaultOptions.terminateIdleLambdaTime * 1000));
+  t.false(Number.isNaN(defaultOptions.functionCleanupIdleTimeSeconds * 1000));
+});
+
+test('#158 the idle-cleanup defaults match serverless-offline default of 60 seconds', t => {
+  t.is(defaultOptions.terminateIdleLambdaTime, 60);
+  t.is(defaultOptions.functionCleanupIdleTimeSeconds, 60);
 });


### PR DESCRIPTION
## Summary

On idle, `serverless-offline-sqs` could pin **~50% CPU**. Root cause (diagnosed by @raymond-w-ko in #158): serverless-offline's `LambdaFunctionPool` schedules its idle-cleanup timer as `setTimeout(fn, options.<idleOption> * 1000)`. The plugin builds its **own** pool options (`defaultOptions` → provider → custom → cli) and passes them straight to `new Lambda(serverless, this.options)`, so serverless-offline's own defaults never apply. With the option absent, `undefined * 1000 === NaN`, and `setTimeout(fn, NaN)` fires immediately in a tight loop.

## Fix

Add the idle-cleanup default to the plugin's `defaultOptions`. The option key was **renamed** across serverless-offline versions and this plugin's peer range (`^10.0.2 || >=11`) spans both, so both are defaulted to serverless-offline's own default of **60s**:

- `functionCleanupIdleTimeSeconds` — serverless-offline ≤ v12
- `terminateIdleLambdaTime` — serverless-offline ≥ v13 (verified in the installed v13: `LambdaFunctionPool.js` reads `this.#options.terminateIdleLambdaTime * 1000`)

Values stay overridable — `_mergeOptions` overlays `custom`/`cli` options *after* the defaults, so an explicit user setting wins. Unused keys are ignored by whichever serverless-offline version is installed.

> Note: the original issue suggested `functionCleanupIdleTimeSeconds`, which was correct for the serverless-offline of the time but is a **no-op against the current v13 dependency** — hence defaulting `terminateIdleLambdaTime` too.

Fixes #158

## Testing

- `defaultOptions` is exported and unit-tested: the timer argument (`option * 1000`) is now a finite number, never `NaN`, and both keys equal 60. Confirmed failing on `master`, passing here.
- `npx ava packages/serverless-offline-sqs/test/index.js` → **23/23**; `npx eslint packages/serverless-offline-sqs/` clean.
- No dependency/`package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)