### PR TITLE
fix(serverless-offline-sqs): only send valid SQS attributes when autocreating queues (#225)

### DIFF
--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -1,13 +1,19 @@
 const SQSClient = require('aws-sdk/clients/sqs');
 
 const {
+  assign,
   chunk,
+  endsWith,
   find,
+  fromPairs,
   get,
+  isArray,
+  isEmpty,
   isPlainObject,
   mapValues,
   matches,
   omit,
+  pick,
   pipe,
   toString,
   values
@@ -41,6 +47,63 @@ const resolveQueueName = (options, rawSqsEventDefinition) => {
       : rawSqsEventDefinition;
 
   return {...omit(['arn'], base), queueName: options.queueName};
+};
+
+// #225 (tomusiaka): only these CloudFormation Properties are valid SQS createQueue Attributes.
+// Everything else (notably QueueName, and Tags which goes through the separate `tags` param) must
+// NOT be sent as an Attribute, or AWS/sqslite reject the request with
+// `InvalidAttributeName: Unknown Attribute QueueName`.
+const SQS_ATTRIBUTE_KEYS = [
+  'DelaySeconds',
+  'MaximumMessageSize',
+  'MessageRetentionPeriod',
+  'Policy',
+  'ReceiveMessageWaitTimeSeconds',
+  'VisibilityTimeout',
+  'RedrivePolicy',
+  'RedriveAllowPolicy',
+  'KmsMasterKeyId',
+  'KmsDataKeyReusePeriodSeconds',
+  'SqsManagedSseEnabled',
+  'FifoQueue',
+  'ContentBasedDeduplication',
+  'DeduplicationScope',
+  'FifoThroughputLimit'
+];
+
+const stringifyAttribute = value =>
+  isPlainObject(value) ? JSON.stringify(value) : toString(value);
+
+// #189/#159: a `.fifo`-suffixed queue is FIFO on AWS regardless of the CloudFormation flag, so infer
+// FifoQueue from the name too (a resource that omits FifoQueue would otherwise be created standard
+// and reject MessageGroupId).
+const isFifoQueue = (queueName, properties) =>
+  endsWith('.fifo', queueName) || properties.FifoQueue === true || properties.FifoQueue === 'true';
+
+// CloudFormation `Tags` is a list of `{Key, Value}` pairs, but the SQS createQueue `tags` param is a
+// flat `{key: value}` map — normalize the list form (a plain map is passed through unchanged).
+const normalizeTags = tags => {
+  if (isEmpty(tags)) return undefined;
+  if (isArray(tags)) return fromPairs(tags.map(({Key, Value}) => [Key, Value]));
+  return tags;
+};
+
+// toCreateQueueParams(queueName, properties) -> {QueueName, Attributes, tags?}
+// Pure + non-mutating: builds the SQS createQueue params from a CloudFormation Queue Properties
+// object, keeping only valid SQS attribute keys (stringified), routing Tags to the `tags` param,
+// and forcing FifoQueue for `.fifo` names.
+const toCreateQueueParams = (queueName, properties = {}) => {
+  const picked = pick(SQS_ATTRIBUTE_KEYS, properties);
+  const attributes = isFifoQueue(queueName, properties)
+    ? assign(picked, {FifoQueue: true})
+    : picked;
+  const tags = normalizeTags(get('Tags', properties));
+
+  return {
+    ...(tags ? {tags} : {}),
+    QueueName: queueName,
+    Attributes: mapValues(stringifyAttribute, attributes)
+  };
 };
 
 class SQS {
@@ -173,15 +236,7 @@ class SQS {
   async _createQueue({queueName}, remainingTry = 5) {
     try {
       const properties = this._getResourceProperties(queueName);
-      await this.client
-        .createQueue({
-          QueueName: queueName,
-          Attributes: mapValues(
-            value => (isPlainObject(value) ? JSON.stringify(value) : toString(value)),
-            properties
-          )
-        })
-        .promise();
+      await this.client.createQueue(toCreateQueueParams(queueName, properties)).promise();
     } catch (err) {
       if (remainingTry > 0 && err.name === 'AWS.SimpleQueueService.NonExistentQueue')
         return this._createQueue({queueName}, remainingTry - 1);
@@ -193,3 +248,4 @@ class SQS {
 module.exports = SQS;
 module.exports.toDeleteEntries = toDeleteEntries;
 module.exports.resolveQueueName = resolveQueueName;
+module.exports.toCreateQueueParams = toCreateQueueParams;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const test = require('ava');
 
 const {defaultLog, normalizeLog} = require('../src/log');
-const {toDeleteEntries, resolveQueueName} = require('../src/sqs');
+const {toDeleteEntries, resolveQueueName, toCreateQueueParams} = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
 const {defaultOptions, isPluginEnabled} = require('../src');
@@ -261,4 +261,85 @@ test('#222 isPluginEnabled is a pure read with no side effects on its input', t 
 test('#222 defaultOptions carries no plugin-level enabled (absence means enabled)', t => {
   // the plugin-wide toggle is opt-out only and must not collide with the per-event enabled property
   t.false('enabled' in defaultOptions);
+});
+
+// ---------------------------------------------------------------------------
+// toCreateQueueParams — explicit-queue creation hardening (#225 tomusiaka)
+// + FIFO inference (#159 / #189)
+// ---------------------------------------------------------------------------
+
+test('#225 toCreateQueueParams never puts QueueName into Attributes', t => {
+  const params = toCreateQueueParams('MyQueue', {QueueName: 'MyQueue', VisibilityTimeout: 30});
+  t.is(params.QueueName, 'MyQueue');
+  t.false('QueueName' in params.Attributes);
+  t.is(params.Attributes.VisibilityTimeout, '30');
+});
+
+test('#225 toCreateQueueParams keeps only valid SQS attribute keys, stringified', t => {
+  const params = toCreateQueueParams('MyQueue', {
+    QueueName: 'MyQueue',
+    VisibilityTimeout: 30,
+    RedrivePolicy: {deadLetterTargetArn: 'arn:aws:sqs:eu-west-1:0:dlq', maxReceiveCount: 5},
+    BogusKey: 'nope'
+  });
+  t.deepEqual(params.Attributes, {
+    VisibilityTimeout: '30',
+    RedrivePolicy: '{"deadLetterTargetArn":"arn:aws:sqs:eu-west-1:0:dlq","maxReceiveCount":5}'
+  });
+  t.is(params.Attributes.BogusKey, undefined); // unknown keys dropped, not forwarded
+});
+
+test('#225 toCreateQueueParams routes CloudFormation Tags to the tags param, not Attributes', t => {
+  const params = toCreateQueueParams('MyQueue', {QueueName: 'MyQueue', Tags: {team: 'core'}});
+  t.is(params.Attributes.Tags, undefined);
+  t.deepEqual(params.tags, {team: 'core'});
+});
+
+test('#225 toCreateQueueParams normalizes CloudFormation list-form Tags to a map', t => {
+  // CloudFormation AWS::SQS::Queue Tags is a list of {Key, Value}; the SQS `tags` param is a map.
+  const params = toCreateQueueParams('MyQueue', {
+    QueueName: 'MyQueue',
+    Tags: [
+      {Key: 'team', Value: 'core'},
+      {Key: 'env', Value: 'dev'}
+    ]
+  });
+  t.deepEqual(params.tags, {team: 'core', env: 'dev'});
+  t.is(params.Attributes.Tags, undefined);
+});
+
+test('#225 toCreateQueueParams omits the tags param when no Tags are present', t => {
+  const params = toCreateQueueParams('MyQueue', {QueueName: 'MyQueue'});
+  t.false('tags' in params);
+  t.deepEqual(params.Attributes, {});
+});
+
+test('#225 toCreateQueueParams tolerates missing/empty properties (implicit autoCreate queue)', t => {
+  t.deepEqual(toCreateQueueParams('Implicit', undefined), {QueueName: 'Implicit', Attributes: {}});
+  t.deepEqual(toCreateQueueParams('Implicit', {}), {QueueName: 'Implicit', Attributes: {}});
+});
+
+test('#225 toCreateQueueParams does not mutate the input properties', t => {
+  const properties = {QueueName: 'MyQueue', VisibilityTimeout: 30, Tags: {a: 'b'}};
+  const before = JSON.parse(JSON.stringify(properties));
+  toCreateQueueParams('MyQueue', properties);
+  t.deepEqual(properties, before);
+});
+
+test('#159 toCreateQueueParams keeps FifoQueue for a FIFO resource (FifoQueue: true)', t => {
+  const {Attributes} = toCreateQueueParams('p-queue.fifo', {
+    QueueName: 'p-queue.fifo',
+    FifoQueue: true,
+    ContentBasedDeduplication: true
+  });
+  t.is(Attributes.FifoQueue, 'true');
+  t.is(Attributes.ContentBasedDeduplication, 'true');
+});
+
+test('#189 toCreateQueueParams infers FIFO from a .fifo name even without the FifoQueue flag', t => {
+  t.is(toCreateQueueParams('orders.fifo', {}).Attributes.FifoQueue, 'true');
+});
+
+test('toCreateQueueParams leaves a standard queue without a FifoQueue attribute', t => {
+  t.false('FifoQueue' in toCreateQueueParams('plain-queue', {QueueName: 'plain-queue'}).Attributes);
 });


### PR DESCRIPTION
## Summary

`autoCreate` was broken on strict backends. `_createQueue` poured the **entire** CloudFormation `Properties` object into the SQS `createQueue` `Attributes` map via `mapValues` — including `QueueName` and `Tags`. AWS SQS and sqslite reject those with **`InvalidAttributeName: Unknown Attribute QueueName`**, so explicit queue creation failed (#225, @tomusiaka).

## Fix

Extract a pure, exported `toCreateQueueParams(queueName, properties)` that builds the createQueue params correctly:

- **whitelists** only the documented SQS createQueue attribute keys (stringified) — verified against the aws-sdk v2 `CreateQueueRequest.Attributes` spec;
- **routes `Tags`** to the separate `tags` param, normalizing CloudFormation list-form `[{Key, Value}]` to the SDK's flat `{key: value}` map;
- **never** sends `QueueName` as an attribute;
- **infers `FifoQueue`** from a `.fifo` name suffix, so a resource that omits the `FifoQueue` flag is still created as FIFO (hardening for #159/#189).

Fixes #225

## Testing

- 10 new AVA cases on the pure helper (QueueName never in Attributes, only-valid-keys, Tags map+list normalization, FIFO inference, implicit/empty path, no input mutation). Confirmed failing on `master`, passing here.
- The autocreate integration fixture (`AutocreatedFifoQueue.fifo` with FifoQueue/MessageRetentionPeriod/ContentBasedDeduplication) keeps those as stringified Attributes while dropping the invalid QueueName attribute.
- `npx ava packages/serverless-offline-sqs/test/index.js` → **33/33**; `eslint` clean. Independently adversarially reviewed (no regressions; whitelist cross-checked against the SDK spec).

> Related: this also hardens **#159 / #189** (FIFO `.fifo` inference + clean attribute creation). #159's specific *ElasticMQ* symptom isn't separately reproducible (the existing `test-sqs-autocreate.js` CI fixture already creates a working FIFO queue on ElasticMQ), so it isn't claimed as auto-closed here — but strict-backend FIFO creation is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)