### PR TITLE
feat(serverless-offline-sqs): maximumBatchingWindow + partial batch failure reporting (#227, #221)

### DIFF
--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -3,12 +3,19 @@ const SQSClient = require('aws-sdk/clients/sqs');
 const {
   assign,
   chunk,
+  clamp,
   endsWith,
+  filter,
   find,
+  flatMap,
   fromPairs,
   get,
+  getOr,
+  includes,
   isArray,
   isEmpty,
+  isFinite,
+  isNil,
   isPlainObject,
   mapValues,
   matches,
@@ -106,6 +113,38 @@ const toCreateQueueParams = (queueName, properties = {}) => {
   };
 };
 
+// SQS ReceiveMessage long-poll caps WaitTimeSeconds at 20, even though the serverless
+// maximumBatchingWindow property accepts 0-300.
+const SQS_MAX_WAIT_TIME_SECONDS = 20;
+
+// #227 (tomusiaka): honor the event-level `maximumBatchingWindow` as the receiveMessage
+// WaitTimeSeconds instead of a hard-coded 5. Clamp to the SQS long-poll range [0, 20]; fall back to
+// the previous default when the option is absent or not a finite number (0 is honored, not falsy).
+const resolveWaitTimeSeconds = (sqsEvent, defaultWaitTimeSeconds) =>
+  isFinite(get('maximumBatchingWindow', sqsEvent))
+    ? clamp(0, SQS_MAX_WAIT_TIME_SECONDS, sqsEvent.maximumBatchingWindow)
+    : defaultWaitTimeSeconds;
+
+// #221 (successkrisz): support SQS partial batch failure reporting. When the event mapping sets
+// `functionResponseType: ReportBatchItemFailures`, the handler returns
+// `{batchItemFailures: [{itemIdentifier: messageId}]}` and only the successes must be deleted so the
+// rest are redriven. Pure + immutable: returns the subset of `messages` to delete.
+//   - legacy mode (reportBatchItemFailures false): delete the whole batch (unchanged behavior)
+//   - thrown handler (failed): delete nothing -> redrive the whole batch
+//   - report mode: delete every message whose MessageId is NOT a reported itemIdentifier
+//     (empty/absent batchItemFailures => full-batch success => delete all)
+const partitionBatchForDeletion = (messages, {reportBatchItemFailures, result, failed} = {}) => {
+  if (!reportBatchItemFailures) return messages || [];
+  if (failed) return [];
+
+  const failedIds = flatMap(
+    item => (item && !isNil(item.itemIdentifier) ? [String(item.itemIdentifier)] : []),
+    getOr([], 'batchItemFailures', result)
+  );
+
+  return filter(({MessageId}) => !includes(String(MessageId), failedIds), messages || []);
+};
+
 class SQS {
   constructor(lambda, resources, options, log) {
     this.lambda = null;
@@ -166,7 +205,7 @@ class SQS {
   }
 
   async _sqsEvent(functionKey, sqsEvent) {
-    const {enabled, arn, queueName, batchSize = 10} = sqsEvent;
+    const {enabled, arn, queueName, batchSize = 10, functionResponseType} = sqsEvent;
 
     if (!enabled) return;
 
@@ -175,6 +214,11 @@ class SQS {
     const QueueUrl = this._rewriteQueueUrl(
       (await this.client.getQueueUrl({QueueName: queueName}).promise()).QueueUrl
     );
+
+    // #227 (tomusiaka): use maximumBatchingWindow as the long-poll wait (default 5s) per queue.
+    const WaitTimeSeconds = resolveWaitTimeSeconds(sqsEvent, 5);
+    // #221 (successkrisz): only honor partial-batch-failure when the mapping opts in.
+    const reportBatchItemFailures = functionResponseType === 'ReportBatchItemFailures';
 
     const getMessages = async (size, messages = []) => {
       if (size <= 0) return messages;
@@ -185,7 +229,7 @@ class SQS {
           MaxNumberOfMessages: size > 10 ? 10 : size,
           AttributeNames: ['All'],
           MessageAttributeNames: ['All'],
-          WaitTimeSeconds: 5
+          WaitTimeSeconds
         })
         .promise();
 
@@ -203,18 +247,24 @@ class SQS {
           const event = new SQSEvent(messages, this.options.region, arn);
           lambdaFunction.setEvent(event);
 
-          await lambdaFunction.runHandler();
+          // #221 (successkrisz): capture the handler result so ReportBatchItemFailures can keep the
+          // failed records for redrive. A thrown handler is caught below and deletes nothing.
+          const result = await lambdaFunction.runHandler();
 
-          await Promise.all(
-            chunk(10, toDeleteEntries(messages)).map(Entries =>
-              this.client
-                .deleteMessageBatch({
-                  Entries,
-                  QueueUrl
-                })
-                .promise()
-            )
-          );
+          const toDelete = partitionBatchForDeletion(messages, {reportBatchItemFailures, result});
+
+          if (toDelete.length > 0) {
+            await Promise.all(
+              chunk(10, toDeleteEntries(toDelete)).map(Entries =>
+                this.client
+                  .deleteMessageBatch({
+                    Entries,
+                    QueueUrl
+                  })
+                  .promise()
+              )
+            );
+          }
         } catch (err) {
           this.log.warning(err.stack);
         }
@@ -249,3 +299,5 @@ module.exports = SQS;
 module.exports.toDeleteEntries = toDeleteEntries;
 module.exports.resolveQueueName = resolveQueueName;
 module.exports.toCreateQueueParams = toCreateQueueParams;
+module.exports.resolveWaitTimeSeconds = resolveWaitTimeSeconds;
+module.exports.partitionBatchForDeletion = partitionBatchForDeletion;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -3,7 +3,13 @@ const path = require('path');
 const test = require('ava');
 
 const {defaultLog, normalizeLog} = require('../src/log');
-const {toDeleteEntries, resolveQueueName, toCreateQueueParams} = require('../src/sqs');
+const {
+  toDeleteEntries,
+  resolveQueueName,
+  toCreateQueueParams,
+  resolveWaitTimeSeconds,
+  partitionBatchForDeletion
+} = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
 const {defaultOptions, isPluginEnabled} = require('../src');
@@ -446,4 +452,114 @@ test('#189 toCreateQueueParams infers FIFO from a .fifo name even without the Fi
 
 test('toCreateQueueParams leaves a standard queue without a FifoQueue attribute', t => {
   t.false('FifoQueue' in toCreateQueueParams('plain-queue', {QueueName: 'plain-queue'}).Attributes);
+});
+
+// ---------------------------------------------------------------------------
+// resolveWaitTimeSeconds — maximumBatchingWindow support (#227 tomusiaka)
+// ---------------------------------------------------------------------------
+
+test('#227 resolveWaitTimeSeconds falls back to the default when unset', t => {
+  t.is(resolveWaitTimeSeconds({}, 5), 5);
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: undefined}, 5), 5);
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 'oops'}, 5), 5);
+});
+
+test('#227 resolveWaitTimeSeconds honors 0 (instant short-poll), not treated as falsy', t => {
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 0}, 5), 0);
+});
+
+test('#227 resolveWaitTimeSeconds passes through a valid in-range value', t => {
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 20}, 5), 20);
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 12}, 5), 12);
+});
+
+test('#227 resolveWaitTimeSeconds clamps to the SQS long-poll max of 20s', t => {
+  // serverless allows maximumBatchingWindow up to 300, but ReceiveMessage WaitTimeSeconds maxes at 20
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 300}, 5), 20);
+});
+
+test('#227 resolveWaitTimeSeconds clamps negatives to 0', t => {
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: -3}, 5), 0);
+});
+
+// ---------------------------------------------------------------------------
+// partitionBatchForDeletion — partial batch failure reporting (#221 successkrisz)
+// ---------------------------------------------------------------------------
+
+const mkMessages = ids => ids.map(id => ({MessageId: id, ReceiptHandle: `rh-${id}`}));
+
+test('#221 partitionBatchForDeletion deletes the whole batch when report mode is OFF', t => {
+  const messages = mkMessages(['a', 'b', 'c']);
+  const toDelete = partitionBatchForDeletion(messages, {
+    reportBatchItemFailures: false,
+    result: {batchItemFailures: [{itemIdentifier: 'b'}]} // ignored in legacy mode
+  });
+  t.deepEqual(
+    toDelete.map(({MessageId}) => MessageId),
+    ['a', 'b', 'c']
+  );
+});
+
+test('#221 partitionBatchForDeletion deletes only the successes in report mode', t => {
+  const messages = mkMessages(['a', 'b', 'c']);
+  const toDelete = partitionBatchForDeletion(messages, {
+    reportBatchItemFailures: true,
+    result: {batchItemFailures: [{itemIdentifier: 'b'}]}
+  });
+  t.deepEqual(
+    toDelete.map(({MessageId}) => MessageId),
+    ['a', 'c']
+  );
+  // the failed message is NOT deleted -> SQS redrives it
+  t.false(toDelete.some(({ReceiptHandle}) => ReceiptHandle === 'rh-b'));
+});
+
+test('#221 partitionBatchForDeletion treats empty/absent batchItemFailures as full success', t => {
+  const messages = mkMessages(['a', 'b']);
+  t.is(partitionBatchForDeletion(messages, {reportBatchItemFailures: true, result: {}}).length, 2);
+  t.is(
+    partitionBatchForDeletion(messages, {
+      reportBatchItemFailures: true,
+      result: {batchItemFailures: []}
+    }).length,
+    2
+  );
+  t.is(
+    partitionBatchForDeletion(messages, {reportBatchItemFailures: true, result: null}).length,
+    2
+  );
+});
+
+test('#221 partitionBatchForDeletion deletes nothing on total failure (thrown handler)', t => {
+  const messages = mkMessages(['a', 'b']);
+  t.deepEqual(
+    partitionBatchForDeletion(messages, {reportBatchItemFailures: true, failed: true}),
+    []
+  );
+});
+
+test('#221 partitionBatchForDeletion tolerates unknown and duplicate itemIdentifiers', t => {
+  const messages = mkMessages(['a', 'b']);
+  const toDelete = partitionBatchForDeletion(messages, {
+    reportBatchItemFailures: true,
+    result: {
+      batchItemFailures: [{itemIdentifier: 'b'}, {itemIdentifier: 'zzz'}, {itemIdentifier: 'b'}]
+    }
+  });
+  t.deepEqual(
+    toDelete.map(({MessageId}) => MessageId),
+    ['a']
+  );
+});
+
+test('#221 partitionBatchForDeletion survivors feed toDeleteEntries with fresh unique Ids', t => {
+  const messages = mkMessages(['a', 'b', 'c']);
+  const kept = partitionBatchForDeletion(messages, {
+    reportBatchItemFailures: true,
+    result: {batchItemFailures: [{itemIdentifier: 'b'}]}
+  });
+  t.deepEqual(toDeleteEntries(kept), [
+    {Id: '0', ReceiptHandle: 'rh-a'},
+    {Id: '1', ReceiptHandle: 'rh-c'}
+  ]);
 });


### PR DESCRIPTION
## Summary

The poll loop hard-coded `WaitTimeSeconds: 5` and always deleted the whole received batch, so two SQS event-source-mapping features were unsupported. Both are now implemented as pure, exported helpers.

### #227 — `maximumBatchingWindow` (@tomusiaka)

`resolveWaitTimeSeconds(sqsEvent, default)` reads the event-level `maximumBatchingWindow` (serverless allows 0–300s) and uses it as the `receiveMessage` long-poll wait, **clamped to the SQS `WaitTimeSeconds` range [0, 20]**. Falls back to the previous `5` when absent or non-finite; `0` is honored (instant short-poll), not treated as falsy.

### #221 — `ReportBatchItemFailures` (@successkrisz)

When the event mapping sets `functionResponseType: ReportBatchItemFailures`, `job()` now captures the handler's return value and a pure `partitionBatchForDeletion` deletes **only** the messages whose `MessageId` is *not* listed in `{batchItemFailures: [{itemIdentifier}]}` — so failed records are left for SQS to redrive. A thrown handler (caught as before) deletes nothing → the whole batch is redriven. Legacy handlers (no `functionResponseType`) keep deleting the whole batch, unchanged.

Fixes #227
Fixes #221

## Testing

- 11 new AVA cases across both pure helpers (clamp/honor-0/default; report-on/off, partial failure, total failure, unknown+dup itemIdentifiers, survivors feed `toDeleteEntries`). Confirmed failing on `master`, passing here.
- Verified against the installed deps: serverless event field is `maximumBatchingWindow`; `serverless-offline` `LambdaFunction.runHandler` returns the handler result; lodash/fp `clamp(0,20,v)` arg order and strict `isFinite` semantics. Independently adversarially reviewed — **no regressions** (default polling timing & deletion are byte-identical when neither property is set).
- `npx ava packages/serverless-offline-sqs/test/index.js` → **34/34**; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)