### PR TITLE
feat(serverless-offline-sqs): add a local disable toggle (#222)

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -107,7 +107,15 @@ custom:
     secretAccessKey: root
     skipCacheInvalidation: false
     queueName: my-local-queue        # optional: override every sqs event's queue name locally
+    enabled: true                    # optional: set false to skip the SQS emulator locally (#222)
 ```
+
+#### Disabling the plugin locally (#222)
+
+Set `custom.serverless-offline-sqs.enabled: false` (or pass `--enabled false`) to skip the SQS
+emulator entirely while still running your HTTP lambdas under `serverless-offline`. This is handy when
+you only want to test a few HTTP functions and don't want to start ElasticMQ/Docker. The plugin is
+enabled by default when the flag is absent.
 
 #### `queueName` override
 

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -3,6 +3,7 @@ const {
   fromPairs,
   get,
   has,
+  isNil,
   isPlainObject,
   isUndefined,
   map,
@@ -38,6 +39,17 @@ const defaultOptions = {
 
 const omitUndefined = omitBy(isUndefined);
 
+// #222 (gndelia): allow locally skipping the whole SQS emulator (e.g. when only HTTP lambdas are
+// needed and no local queue system is running) without commenting out the plugin. Honors
+// `custom.serverless-offline-sqs.enabled: false` (also a `--enabled false` CLI flag); enabled by
+// default when unset. YAML/CLI may deliver the value as the string "false", so treat that as off too.
+const isPluginEnabled = options => {
+  const enabled = get('enabled', options);
+  if (isNil(enabled)) return true;
+  if (enabled === 'false') return false;
+  return Boolean(enabled);
+};
+
 class ServerlessOfflineSQS {
   constructor(serverless, cliOptions, {log} = {}) {
     this.cliOptions = cliOptions;
@@ -63,7 +75,9 @@ class ServerlessOfflineSQS {
 
     const eventModules = [];
 
-    if (sqsEvents.length > 0) {
+    // #222 (gndelia): skip SQS setup entirely when disabled, but still create the lambdas so plain
+    // HTTP functions keep working under serverless-offline.
+    if (isPluginEnabled(this.options) && sqsEvents.length > 0) {
       eventModules.push(this._createSqs(sqsEvents));
     }
 
@@ -240,3 +254,4 @@ class ServerlessOfflineSQS {
 
 module.exports = ServerlessOfflineSQS;
 module.exports.defaultOptions = defaultOptions;
+module.exports.isPluginEnabled = isPluginEnabled;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -6,7 +6,7 @@ const {defaultLog, normalizeLog} = require('../src/log');
 const {toDeleteEntries, resolveQueueName} = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
-const {defaultOptions} = require('../src');
+const {defaultOptions, isPluginEnabled} = require('../src');
 
 // ---------------------------------------------------------------------------
 // normalizeLog
@@ -229,4 +229,36 @@ test('#158 defaultOptions sets a finite idle-cleanup time so the pool timer is n
 test('#158 the idle-cleanup defaults match serverless-offline default of 60 seconds', t => {
   t.is(defaultOptions.terminateIdleLambdaTime, 60);
   t.is(defaultOptions.functionCleanupIdleTimeSeconds, 60);
+});
+
+// ---------------------------------------------------------------------------
+// isPluginEnabled — local disable toggle (#222 gndelia)
+// ---------------------------------------------------------------------------
+
+test('#222 isPluginEnabled defaults to true when the flag is absent', t => {
+  t.true(isPluginEnabled({}));
+  t.true(isPluginEnabled(undefined));
+  t.true(isPluginEnabled({region: 'eu-west-1', autoCreate: true}));
+});
+
+test('#222 isPluginEnabled honors an explicit enabled:false (boolean or string)', t => {
+  t.false(isPluginEnabled({enabled: false}));
+  t.false(isPluginEnabled({enabled: 'false'}));
+});
+
+test('#222 isPluginEnabled stays enabled for truthy/explicit-true values', t => {
+  t.true(isPluginEnabled({enabled: true}));
+  t.true(isPluginEnabled({enabled: 'true'}));
+});
+
+test('#222 isPluginEnabled is a pure read with no side effects on its input', t => {
+  const opts = {enabled: false, region: 'eu-west-1'};
+  const before = {...opts};
+  isPluginEnabled(opts);
+  t.deepEqual(opts, before);
+});
+
+test('#222 defaultOptions carries no plugin-level enabled (absence means enabled)', t => {
+  // the plugin-wide toggle is opt-out only and must not collide with the per-event enabled property
+  t.false('enabled' in defaultOptions);
 });


### PR DESCRIPTION
## Summary

`start()` unconditionally wired the SQS emulator whenever any `sqs` event existed. If the local queue system (ElasticMQ/Docker) wasn't running, `_getQueueUrl` retried forever and offline startup effectively hung — even for users who only wanted to run a few **HTTP** lambdas (#222, @gndelia).

## Fix

A pure, exported `isPluginEnabled(options)` helper honoring `custom.serverless-offline-sqs.enabled: false` (also `--enabled false`; the string `"false"` counts as off). `start()` skips **all** SQS wiring when disabled while **still creating the lambdas**, so HTTP functions keep working. Enabled by default when the flag is absent, so behavior is unchanged for everyone else.

This is a **plugin-wide** toggle, intentionally separate from the per-event `enabled` property. Shutdown stays safe — `end()` already guards `if (this.sqs)`, and `this.sqs` is simply never created when disabled.

Fixes #222

## Testing

- 5 new AVA cases on the pure helper (default-true; `false`/`'false'` off; `true`/`'true'` on; no input mutation; `defaultOptions` carries no `enabled`). Confirmed failing on `master`, passing here.
- Independently adversarially reviewed: `enabled` correctly reaches `this.options` via `_mergeOptions` (custom beats provider, CLI beats custom); the absent-flag path is byte-identical to `master`; no collision with the per-event `enabled`; safe shutdown.
- `npx ava packages/serverless-offline-sqs/test/index.js` → **28/28**; `eslint` clean. README documents the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)