### PR TITLE
feat(serverless-offline-sqs): fan out multi-queue queueName into one listener per queue (#262)

### DIFF
--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -2,8 +2,10 @@ const SQSClient = require('aws-sdk/clients/sqs');
 
 const {
   assign,
+  castArray,
   chunk,
   clamp,
+  compact,
   endsWith,
   filter,
   find,
@@ -17,6 +19,7 @@ const {
   isFinite,
   isNil,
   isPlainObject,
+  isString,
   keyBy,
   map,
   mapValues,
@@ -25,7 +28,10 @@ const {
   pick,
   pipe,
   reduce,
+  split,
   toString,
+  trim,
+  uniq,
   values
 } = require('lodash/fp');
 const {default: PQueue} = require('p-queue');
@@ -59,6 +65,56 @@ const resolveQueueName = (options, rawSqsEventDefinition) => {
       : rawSqsEventDefinition;
 
   return {...omit(['arn'], base), queueName: options.queueName};
+};
+
+// #262 (renanlido): a single SQS event may target MULTIPLE queues. The `queueName` (event-level
+// or the custom.serverless-offline-sqs.queueName / --queueName override) may be:
+//   - a scalar string            'orders'
+//   - a comma-separated string   'orders, billing'   (CLI form: --queueName a,b)
+//   - an array of either         ['orders', 'billing,audit']
+// Normalize all of these into a de-duplicated, trimmed string[]. Anything falsy/empty -> [].
+// Note: this is for *literal* queue names only; ARN strings are left to the SQSEventDefinition
+// ARN-extraction path (#74/#200) and never reach here (see expandSqsEventDefinitions). Pure +
+// non-throwing: castArray(undefined|null) yields a one-element array whose non-string member is
+// dropped, so empty/nullish input resolves to [] without throwing.
+const normalizeQueueNames = pipe(
+  castArray,
+  flatMap(name => (isString(name) ? split(',', name) : [])),
+  map(trim),
+  compact, // drop '' produced by trailing/double commas
+  uniq
+);
+
+// #262 (renanlido): expand an SQS event definition into one definition per target queue, so an
+// array / comma-separated `queueName` (event-level or via the --queueName override) becomes one
+// independent SQSEventDefinition + poll loop per queue instead of a single malformed listener.
+// Pure + non-mutating: returns a fresh array of definitions (one per resolved queue name).
+//   - Override precedence and the #211 arn-strip contract are preserved: when options.queueName is
+//     set it WINS and `arn`/`queueName` are stripped so SQSEventDefinition rebuilds the ARN from
+//     the override.
+//   - With NO override and NO literal event-level queueName (an ARN/intrinsic string or {arn}
+//     object), the input is passed straight through as a single-element array so the existing
+//     extractQueueNameFromARN/resolveCfnValue path (#74/#200) keeps owning name derivation.
+const expandSqsEventDefinitions = (options, rawSqsEventDefinition) => {
+  const overrideNames = normalizeQueueNames(get('queueName', options));
+
+  if (!isEmpty(overrideNames)) {
+    const base = isString(rawSqsEventDefinition)
+      ? {}
+      : omit(['arn', 'queueName'], rawSqsEventDefinition);
+    return overrideNames.map(queueName => ({...base, queueName}));
+  }
+
+  // No override: only fan out a *literal* array/comma event-level queueName. An ARN string or an
+  // {arn}/intrinsic object (no literal queueName) is passed straight through (single listener).
+  const eventNames = isString(rawSqsEventDefinition)
+    ? []
+    : normalizeQueueNames(get('queueName', rawSqsEventDefinition));
+
+  if (eventNames.length <= 1) return [rawSqsEventDefinition];
+
+  const base = omit(['queueName'], rawSqsEventDefinition);
+  return eventNames.map(queueName => ({...base, queueName}));
 };
 
 // #225 (tomusiaka): only these CloudFormation Properties are valid SQS createQueue Attributes.
@@ -226,6 +282,15 @@ class SQS {
   async create(events) {
     const {region, accountId} = this.options;
 
+    // #262 (renanlido): fan each event out into one (functionKey, def) per target queue (array /
+    // comma-separated queueName, event-level or via the --queueName override) before creating; each
+    // `def` is a fully-resolved single-queue definition.
+    const definitions = flatMap(
+      ({functionKey, sqs}) =>
+        expandSqsEventDefinitions(this.options, sqs).map(def => ({functionKey, def})),
+      events
+    );
+
     // #65/#133/#167: when autoCreate is on, create EVERY declared queue — including a dead-letter
     // queue that lives only in resources.Resources and is referenced solely via another queue's
     // RedrivePolicy — and create them DLQ-first, sequentially, so createQueue does not reject with
@@ -234,19 +299,16 @@ class SQS {
       const resourceDefs = collectQueueDefinitions(this.resources);
       const resourceNames = new Set(map('queueName', resourceDefs));
 
-      // Union in event-only queues (a string-ARN event with no resources entry) so the existing
-      // implicit-queue autoCreate keeps working; dedupe by queueName so a queue declared BOTH as a
-      // lambda event and a resource is created once, not twice.
+      // Union in event-only queues — including every queue a multi-queue event fanned out to — so
+      // the existing implicit-queue autoCreate keeps working; the defs are already fully resolved by
+      // expandSqsEventDefinitions, so read each queueName directly. Dedupe so a queue declared BOTH
+      // as a lambda event and a resource is created once, not twice.
       const eventDefs = pipe(
-        map(
-          ({sqs}) =>
-            new SQSEventDefinition(resolveQueueName(this.options, sqs), region, accountId).queueName
-        ),
+        map(({def}) => new SQSEventDefinition(def, region, accountId).queueName),
         filter(queueName => !isNil(queueName) && !resourceNames.has(queueName)),
-        // de-duplicate event names that repeat across functions
         queueNames => [...new Set(queueNames)],
         map(queueName => ({queueName, properties: {}}))
-      )(events);
+      )(definitions);
 
       const ordered = orderQueuesForCreation([...resourceDefs, ...eventDefs], region, accountId);
 
@@ -259,7 +321,7 @@ class SQS {
       );
     }
 
-    return Promise.all(events.map(({functionKey, sqs}) => this._create(functionKey, sqs)));
+    return Promise.all(definitions.map(({functionKey, def}) => this._create(functionKey, def)));
   }
 
   start() {
@@ -270,9 +332,10 @@ class SQS {
     this.queue.pause();
   }
 
-  _create(functionKey, rawSqsEventDefinition) {
-    const def = resolveQueueName(this.options, rawSqsEventDefinition);
-
+  _create(functionKey, def) {
+    // #262 (renanlido): `def` is already a fully-resolved single-queue definition produced by
+    // expandSqsEventDefinitions (override-wins + arn-strip handled there), so SQSEventDefinition
+    // only ever sees one queue at a time.
     const sqsEvent = new SQSEventDefinition(def, this.options.region, this.options.accountId);
 
     return this._sqsEvent(functionKey, sqsEvent);
@@ -395,6 +458,8 @@ class SQS {
 module.exports = SQS;
 module.exports.toDeleteEntries = toDeleteEntries;
 module.exports.resolveQueueName = resolveQueueName;
+module.exports.normalizeQueueNames = normalizeQueueNames;
+module.exports.expandSqsEventDefinitions = expandSqsEventDefinitions;
 module.exports.toCreateQueueParams = toCreateQueueParams;
 module.exports.resolveWaitTimeSeconds = resolveWaitTimeSeconds;
 module.exports.partitionBatchForDeletion = partitionBatchForDeletion;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -11,7 +11,9 @@ const {
   partitionBatchForDeletion,
   collectQueueDefinitions,
   extractDlqTargetName,
-  orderQueuesForCreation
+  orderQueuesForCreation,
+  normalizeQueueNames,
+  expandSqsEventDefinitions
 } = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
@@ -730,4 +732,125 @@ test('#87 toCreateQueueParams forwards RedrivePolicy incl. maxReceiveCount for t
     params.Attributes.RedrivePolicy,
     '{"deadLetterTargetArn":"arn:aws:sqs:eu-west-1:000000000000:MainDlq","maxReceiveCount":5}'
   );
+});
+
+// ---------------------------------------------------------------------------
+// normalizeQueueNames / expandSqsEventDefinitions — multi-queue fan-out (#262 renanlido)
+// ---------------------------------------------------------------------------
+
+test('#262 normalizeQueueNames passes a single scalar name through as a one-element array', t => {
+  t.deepEqual(normalizeQueueNames('only'), ['only']);
+});
+
+test('#262 normalizeQueueNames splits a comma-separated string and trims each name', t => {
+  t.deepEqual(normalizeQueueNames('a, b ,c'), ['a', 'b', 'c']);
+});
+
+test('#262 normalizeQueueNames flattens an array (including comma-bearing members)', t => {
+  t.deepEqual(normalizeQueueNames(['a', 'b']), ['a', 'b']);
+  t.deepEqual(normalizeQueueNames(['a', 'b,c']), ['a', 'b', 'c']);
+});
+
+test('#262 normalizeQueueNames de-duplicates repeated names (array and string forms)', t => {
+  t.deepEqual(normalizeQueueNames(['a', 'a', 'b']), ['a', 'b']);
+  t.deepEqual(normalizeQueueNames('a,a,b'), ['a', 'b']);
+});
+
+test('#262 normalizeQueueNames returns [] for empty/nullish input without throwing', t => {
+  t.deepEqual(normalizeQueueNames(undefined), []);
+  t.deepEqual(normalizeQueueNames(null), []);
+  t.deepEqual(normalizeQueueNames(''), []);
+  t.deepEqual(normalizeQueueNames([]), []);
+  t.deepEqual(normalizeQueueNames('  ,  '), []);
+});
+
+test('#262 expandSqsEventDefinitions fans out an array queueName into one def per queue', t => {
+  const defs = expandSqsEventDefinitions({}, {queueName: ['a', 'b'], batchSize: 5});
+  t.deepEqual(defs, [
+    {queueName: 'a', batchSize: 5},
+    {queueName: 'b', batchSize: 5}
+  ]);
+});
+
+test('#262 expandSqsEventDefinitions fans out a comma-separated event queueName', t => {
+  const defs = expandSqsEventDefinitions({}, {queueName: 'a,b,c'});
+  t.deepEqual(defs, [{queueName: 'a'}, {queueName: 'b'}, {queueName: 'c'}]);
+});
+
+test('#262 expandSqsEventDefinitions yields a single def for a scalar queueName (no behavior change)', t => {
+  t.deepEqual(expandSqsEventDefinitions({}, {queueName: 'only'}), [{queueName: 'only'}]);
+});
+
+test('#262 expandSqsEventDefinitions: override (array) wins and fans out, stripping arn (#211 guard)', t => {
+  const event = {arn: 'arn:aws:sqs:eu-west-1:0:fromEvent', batchSize: 3};
+  const defs = expandSqsEventDefinitions({queueName: ['x', 'y']}, event);
+  t.deepEqual(defs, [
+    {queueName: 'x', batchSize: 3},
+    {queueName: 'y', batchSize: 3}
+  ]);
+  // each rebuilds its ARN downstream from the override (the #211 arn-strip contract)
+  const built = defs.map(d => new SQSEventDefinition(d, 'eu-west-1', '000000000000'));
+  t.deepEqual(
+    built.map(b => b.queueName),
+    ['x', 'y']
+  );
+  t.is(built[0].arn, 'arn:aws:sqs:eu-west-1:000000000000:x');
+});
+
+test('#262 expandSqsEventDefinitions: comma-separated override wins over event-level array', t => {
+  const defs = expandSqsEventDefinitions(
+    {queueName: 'x, y'},
+    {queueName: ['a', 'b'], batchSize: 1}
+  );
+  t.deepEqual(defs, [
+    {queueName: 'x', batchSize: 1},
+    {queueName: 'y', batchSize: 1}
+  ]);
+});
+
+test('#262 expandSqsEventDefinitions preserves all other props on every fanned-out def', t => {
+  const event = {
+    queueName: ['a', 'b'],
+    batchSize: 7,
+    enabled: false,
+    maximumBatchingWindow: 10,
+    functionResponseType: 'ReportBatchItemFailures'
+  };
+  const defs = expandSqsEventDefinitions({}, event);
+  defs.forEach(d => {
+    t.is(d.batchSize, 7);
+    t.is(d.enabled, false);
+    t.is(d.maximumBatchingWindow, 10);
+    t.is(d.functionResponseType, 'ReportBatchItemFailures');
+  });
+});
+
+test('#262 expandSqsEventDefinitions does not mutate the input event or options', t => {
+  const options = {queueName: ['x', 'y']};
+  const event = {queueName: ['a', 'b'], batchSize: 5};
+  const optionsBefore = {queueName: ['x', 'y']};
+  const eventBefore = {queueName: ['a', 'b'], batchSize: 5};
+  expandSqsEventDefinitions(options, event);
+  t.deepEqual(options, optionsBefore);
+  t.deepEqual(event, eventBefore);
+});
+
+test('#262 expandSqsEventDefinitions: string ARN event with no literal queueName stays a single listener (#74/#200 guard)', t => {
+  // No literal queueName, no override => one def, name derived by the ARN path downstream.
+  const defs = expandSqsEventDefinitions({}, 'arn:aws:sqs:eu-west-1:000000000000:Q');
+  t.is(defs.length, 1);
+  const built = new SQSEventDefinition(defs[0], 'eu-west-1', '000000000000');
+  t.is(built.queueName, 'Q');
+  t.is(built.arn, 'arn:aws:sqs:eu-west-1:000000000000:Q');
+});
+
+test('#262 expandSqsEventDefinitions: {arn} object event with no literal queueName stays a single listener', t => {
+  const defs = expandSqsEventDefinitions(
+    {},
+    {arn: 'arn:aws:sqs:eu-west-1:000000000000:Q', batchSize: 2}
+  );
+  t.is(defs.length, 1);
+  const built = new SQSEventDefinition(defs[0], 'eu-west-1', '000000000000');
+  t.is(built.queueName, 'Q');
+  t.is(built.batchSize, 2);
 });


### PR DESCRIPTION
## Summary

#262 (@renanlido) — a single `sqs` event (or the `custom.serverless-offline-sqs.queueName` override) can now name **multiple** queues: an **array** or a **comma-separated string**. The plugin normalizes the value into a trimmed, de-duplicated `string[]` and spins up **one listener per queue**.

Pure exported helpers: `normalizeQueueNames` (scalar / `"a,b,c"` / array → clean `string[]`; nullish/empty/whitespace → `[]` without throwing) and `expandSqsEvent` (fans one event definition into one per queue). Single-queue configs behave exactly as before.

> The fragile `switch("string")` queue-name extraction mentioned in the issue was already rewritten in #270 (`resolveCfnValue`/`extractQueueNameFromARN`); this PR adds only the multi-queue fan-out.

Fixes #262

## Testing

- 14 new AVA cases on the pure helpers (array, CSV, dedup, whitespace/empty handling, single-queue passthrough, fan-out). Confirmed failing on `master`, passing here; 72/72 total. `eslint` clean. Independently adversarially reviewed.

> Merge-order note: touches `sqs.js` alongside #278 (DLQ/redrive). Whichever merges second needs a quick rebase — ping me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)