### PR TITLE
fix(serverless-offline-sqs): migrate from aws-sdk v2 to @aws-sdk/clie…

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -133,7 +133,15 @@ resolved ARN, so a `.fifo` suffix is preserved.
 
 ### SQS
 
-The configuration of [`aws.SQS`'s client](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#constructor-property) of the plugin is done by defining a `custom: serverless-offline-sqs` object in your `serverless.yml` with your specific configuration.
+The SQS client is the AWS SDK for JavaScript **v3**
+([`@aws-sdk/client-sqs`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sqs/)) instead
+of the end-of-support `aws-sdk` v2. This fixes the `SyntaxError: Unexpected token < in JSON` /
+`UnknownError` failures reported against modern endpoints (#260) and removes the SDK-v2
+maintenance-mode warning (#252). The plugin maps your `endpoint`, `region`, `accessKeyId` and
+`secretAccessKey` (plus an optional `sessionToken`) into the v3 `{endpoint, region, credentials}`
+client config; when no `accessKeyId` is set it falls back to the default AWS credential provider
+chain. Configuration is done by defining a `custom: serverless-offline-sqs` object in your
+`serverless.yml`.
 
 You could use [ElasticMQ](https://github.com/adamw/elasticmq) with the following configuration:
 
@@ -141,15 +149,16 @@ You could use [ElasticMQ](https://github.com/adamw/elasticmq) with the following
 custom:
   serverless-offline-sqs:
     autoCreate: true                 # create queue if not exists
-    apiVersion: '2012-11-05'
     endpoint: http://0.0.0.0:9324
     region: eu-west-1
     accessKeyId: root
     secretAccessKey: root
-    skipCacheInvalidation: false
     queueName: my-local-queue        # optional: override every sqs event's queue name locally
     enabled: true                    # optional: set false to skip the SQS emulator locally (#222)
 ```
+
+> The v2-only `apiVersion` / `skipCacheInvalidation` keys are no longer used by the v3 client and can
+> be removed; any extra keys are ignored.
 
 #### Disabling the plugin locally (#222)
 

--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -31,7 +31,7 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-sqs": "^3.1073.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2"
   },

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -1,4 +1,14 @@
-const SQSClient = require('aws-sdk/clients/sqs');
+// #252/#260 (silou): migrated off the end-of-support aws-sdk v2 SQS client (the old
+// aws-sdk/clients/sqs default import), which paired a maintenance-mode client with the modern
+// service and surfaced #260's `SyntaxError: Unexpected token < in JSON` / `UnknownError`. Use the v3
+// modular client + command objects (mirrors the @aws-sdk/client-eventbridge approach in the tree).
+const {
+  SQSClient,
+  GetQueueUrlCommand,
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  DeleteMessageBatchCommand
+} = require('@aws-sdk/client-sqs');
 
 const {
   assign,
@@ -45,6 +55,39 @@ const delay = timeout =>
   new Promise(resolve => {
     setTimeout(resolve, timeout);
   });
+
+// #252/#260 (silou): the plugin merges provider + custom + CLI options into one flat bag (region,
+// endpoint, accessKeyId, secretAccessKey, plus many unrelated keys like stage/batchSize/autoCreate).
+// The v2 client read top-level accessKeyId/secretAccessKey and silently ignored the rest; the v3
+// SQSClient instead expects `{region, endpoint, credentials:{accessKeyId, secretAccessKey,
+// sessionToken?}}`. Map the flat options into that v3 client config. Pure + non-mutating:
+//   - omit `endpoint` when absent so the AWS endpoint resolver runs (real-AWS / non-ElasticMQ use)
+//   - omit `credentials` entirely when no accessKeyId is set, so the default credential provider
+//     chain is used (a half-empty credentials object makes the v3 client throw on first send)
+//   - forward an optional sessionToken for STS/temporary credentials
+const buildSqsClientConfig = options => {
+  const {region, endpoint, accessKeyId, secretAccessKey, sessionToken} = options || {};
+  const credentials = accessKeyId
+    ? {...(sessionToken ? {sessionToken} : {}), accessKeyId, secretAccessKey}
+    : undefined;
+
+  return {
+    ...(region ? {region} : {}),
+    ...(endpoint ? {endpoint} : {}),
+    ...(credentials ? {credentials} : {})
+  };
+};
+
+// #133/#167 + #252/#260 (silou): the DLQ-first createQueue retry keys off the "queue does not exist
+// yet" error (a RedrivePolicy referencing a not-yet-created dead-letter queue). aws-sdk v2 reported
+// this as `AWS.SimpleQueueService.NonExistentQueue`; the v3 @aws-sdk/client-sqs modeled error is
+// `QueueDoesNotExist`. Accept both so the retry survives the migration (and any v2-shaped mock).
+const NON_EXISTENT_QUEUE_ERROR_NAMES = [
+  'QueueDoesNotExist',
+  'AWS.SimpleQueueService.NonExistentQueue'
+];
+
+const isNonExistentQueueError = err => includes(get('name', err), NON_EXISTENT_QUEUE_ERROR_NAMES);
 
 // #253 (flipscholtz): MessageId is not guaranteed unique within a batch and can exceed the 80-char
 // `Id` limit. Derive the batch-entry Id from the array index so it is unique and short.
@@ -274,7 +317,9 @@ class SQS {
     this.options = options;
     this.log = normalizeLog(log);
 
-    this.client = new SQSClient(this.options);
+    // #252/#260 (silou): build the clean v3 client config (region/endpoint/credentials) instead of
+    // handing the whole option bag to the constructor.
+    this.client = new SQSClient(buildSqsClientConfig(this.options));
 
     this.queue = new PQueue({autoStart: false});
   }
@@ -357,7 +402,8 @@ class SQS {
 
   async _getQueueUrl(queueName) {
     try {
-      return await this.client.getQueueUrl({QueueName: queueName}).promise();
+      // #252/#260 (silou): v3 command-object form (was `.getQueueUrl({...}).promise()`).
+      return await this.client.send(new GetQueueUrlCommand({QueueName: queueName}));
     } catch (err) {
       await delay(10000);
       return this._getQueueUrl(queueName);
@@ -372,7 +418,7 @@ class SQS {
     if (this.options.autoCreate) await this._createQueue(sqsEvent);
 
     const QueueUrl = this._rewriteQueueUrl(
-      (await this.client.getQueueUrl({QueueName: queueName}).promise()).QueueUrl
+      (await this.client.send(new GetQueueUrlCommand({QueueName: queueName}))).QueueUrl
     );
 
     // #227 (tomusiaka): use maximumBatchingWindow as the long-poll wait (default 5s) per queue.
@@ -383,15 +429,15 @@ class SQS {
     const getMessages = async (size, messages = []) => {
       if (size <= 0) return messages;
 
-      const {Messages} = await this.client
-        .receiveMessage({
+      const {Messages} = await this.client.send(
+        new ReceiveMessageCommand({
           QueueUrl,
           MaxNumberOfMessages: size > 10 ? 10 : size,
           AttributeNames: ['All'],
           MessageAttributeNames: ['All'],
           WaitTimeSeconds
         })
-        .promise();
+      );
 
       if (!Messages || Messages.length === 0) return messages;
       return getMessages(size - Messages.length, [...messages, ...Messages]);
@@ -416,12 +462,12 @@ class SQS {
           if (toDelete.length > 0) {
             await Promise.all(
               chunk(10, toDeleteEntries(toDelete)).map(Entries =>
-                this.client
-                  .deleteMessageBatch({
+                this.client.send(
+                  new DeleteMessageBatchCommand({
                     Entries,
                     QueueUrl
                   })
-                  .promise()
+                )
               )
             );
           }
@@ -446,9 +492,9 @@ class SQS {
   async _createQueue({queueName}, remainingTry = 5) {
     try {
       const properties = this._getResourceProperties(queueName);
-      await this.client.createQueue(toCreateQueueParams(queueName, properties)).promise();
+      await this.client.send(new CreateQueueCommand(toCreateQueueParams(queueName, properties)));
     } catch (err) {
-      if (remainingTry > 0 && err.name === 'AWS.SimpleQueueService.NonExistentQueue')
+      if (remainingTry > 0 && isNonExistentQueueError(err))
         return this._createQueue({queueName}, remainingTry - 1);
       this.log.warning(err.stack);
     }
@@ -466,3 +512,5 @@ module.exports.partitionBatchForDeletion = partitionBatchForDeletion;
 module.exports.collectQueueDefinitions = collectQueueDefinitions;
 module.exports.extractDlqTargetName = extractDlqTargetName;
 module.exports.orderQueuesForCreation = orderQueuesForCreation;
+module.exports.buildSqsClientConfig = buildSqsClientConfig;
+module.exports.isNonExistentQueueError = isNonExistentQueueError;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -13,7 +13,9 @@ const {
   extractDlqTargetName,
   orderQueuesForCreation,
   normalizeQueueNames,
-  expandSqsEventDefinitions
+  expandSqsEventDefinitions,
+  buildSqsClientConfig,
+  isNonExistentQueueError
 } = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
@@ -853,4 +855,108 @@ test('#262 expandSqsEventDefinitions: {arn} object event with no literal queueNa
   const built = new SQSEventDefinition(defs[0], 'eu-west-1', '000000000000');
   t.is(built.queueName, 'Q');
   t.is(built.batchSize, 2);
+});
+
+// ---------------------------------------------------------------------------
+// buildSqsClientConfig — #252/#260 (aws-sdk v2 -> @aws-sdk/client-sqs v3 migration)
+//
+// The v2 client accepted the plugin's full merged options bag and silently ignored unknown keys
+// AND read `accessKeyId`/`secretAccessKey` at the top level. The v3 SQSClient needs a clean
+// `{region, endpoint, credentials:{accessKeyId, secretAccessKey}}` shape and would otherwise pick up
+// node's default credential chain. buildSqsClientConfig maps the flat options to that v3 shape.
+// ---------------------------------------------------------------------------
+
+test('#260 buildSqsClientConfig maps endpoint/region + flat creds into the v3 client shape', t => {
+  const config = buildSqsClientConfig({
+    endpoint: 'http://localhost:9324',
+    region: 'eu-west-1',
+    accessKeyId: 'local',
+    secretAccessKey: 'local'
+  });
+  t.deepEqual(config, {
+    endpoint: 'http://localhost:9324',
+    region: 'eu-west-1',
+    credentials: {accessKeyId: 'local', secretAccessKey: 'local'}
+  });
+});
+
+test('#260 buildSqsClientConfig forwards sessionToken into credentials when present', t => {
+  const config = buildSqsClientConfig({
+    region: 'us-east-1',
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+    sessionToken: 'TOKEN'
+  });
+  t.deepEqual(config.credentials, {
+    accessKeyId: 'AK',
+    secretAccessKey: 'SK',
+    sessionToken: 'TOKEN'
+  });
+});
+
+test('#260 buildSqsClientConfig omits credentials entirely when no accessKeyId is provided', t => {
+  // Falling back to the default credential provider chain must NOT be shadowed by a half-empty
+  // credentials object (v3 throws on credentials with an undefined accessKeyId).
+  const config = buildSqsClientConfig({region: 'eu-west-1', endpoint: 'http://localhost:9324'});
+  t.false('credentials' in config);
+  t.deepEqual(config, {region: 'eu-west-1', endpoint: 'http://localhost:9324'});
+});
+
+test('#260 buildSqsClientConfig drops unrelated plugin options (stage, batchSize, autoCreate, ...)', t => {
+  const config = buildSqsClientConfig({
+    region: 'eu-west-1',
+    endpoint: 'http://localhost:9324',
+    accessKeyId: 'a',
+    secretAccessKey: 'b',
+    stage: 'dev',
+    batchSize: 100,
+    autoCreate: true,
+    accountId: '000000000000',
+    queueName: 'orders'
+  });
+  t.deepEqual(Object.keys(config).sort(), ['credentials', 'endpoint', 'region']);
+});
+
+test('#260 buildSqsClientConfig omits endpoint when unset (AWS default resolution)', t => {
+  const config = buildSqsClientConfig({
+    region: 'eu-west-1',
+    accessKeyId: 'a',
+    secretAccessKey: 'b'
+  });
+  t.false('endpoint' in config);
+  t.is(config.region, 'eu-west-1');
+});
+
+test('#260 buildSqsClientConfig is pure (does not mutate its input)', t => {
+  const options = {region: 'eu-west-1', accessKeyId: 'a', secretAccessKey: 'b', stage: 'dev'};
+  const before = {...options};
+  buildSqsClientConfig(options);
+  t.deepEqual(options, before);
+});
+
+test('#252 sqs.js no longer depends on the end-of-support aws-sdk v2 client', t => {
+  // #260 surfaced the v2-client + modern-protocol mismatch as `SyntaxError: Unexpected token <`.
+  // Guard the regression: the module source must not require the deprecated v2 SQS client and must
+  // use the v3 `@aws-sdk/client-sqs` package instead.
+  const source = fs.readFileSync(path.join(__dirname, '../src/sqs.js'), 'utf8');
+  t.false(source.includes("require('aws-sdk/clients/sqs')"));
+  t.true(source.includes('@aws-sdk/client-sqs'));
+});
+
+// ---------------------------------------------------------------------------
+// isNonExistentQueueError — #133/#167 DLQ-first retry, name-agnostic across SDK v2/v3 (#252/#260)
+// ---------------------------------------------------------------------------
+
+test('#252 isNonExistentQueueError matches the v3 QueueDoesNotExist error name', t => {
+  t.true(isNonExistentQueueError({name: 'QueueDoesNotExist'}));
+});
+
+test('#252 isNonExistentQueueError still matches the legacy v2 error name', t => {
+  t.true(isNonExistentQueueError({name: 'AWS.SimpleQueueService.NonExistentQueue'}));
+});
+
+test('#252 isNonExistentQueueError is false for unrelated/missing errors (no throw)', t => {
+  t.false(isNonExistentQueueError({name: 'AccessDenied'}));
+  t.false(isNonExistentQueueError({}));
+  t.false(isNonExistentQueueError(undefined));
 });


### PR DESCRIPTION
…nt-sqs v3

Replace the end-of-support `aws-sdk` v2 SQS client (the old `aws-sdk/clients/sqs` default import) with the modular AWS SDK v3 `@aws-sdk/client-sqs`. The v2 client paired a maintenance-mode client with the modern service and surfaced #260's `SyntaxError: Unexpected token < in JSON` / `UnknownError`; v3 fixes this and removes the SDK-v2 maintenance-mode warning (#252).

- Add a pure, unit-tested `buildSqsClientConfig(options)` helper mapping the flat plugin options bag (region/endpoint/accessKeyId/secretAccessKey/sessionToken) into the v3 `{region, endpoint, credentials}` client config. Omits credentials when no accessKeyId is set (falls back to the default provider chain) and omits endpoint when unset (AWS default resolution).
- Replace the 5 `.promise()` call sites (getQueueUrl x2, createQueue, receiveMessage, deleteMessageBatch) with `client.send(new XCommand({...}))`.
- Add `isNonExistentQueueError` so the #133/#167 DLQ-first createQueue retry keys off both the v3 `QueueDoesNotExist` and legacy v2 error names.
- All existing pure helpers (toCreateQueueParams, toDeleteEntries, resolveWaitTimeSeconds, partitionBatchForDeletion, ...) are unchanged.
- Swap the `aws-sdk` dependency for `@aws-sdk/client-sqs` and update the README.

Closes #252
Closes #260