### PR TITLE
fix(serverless-offline-dynamodb-streams): persist stream checkpoints …

### DIFF
--- a/packages/serverless-offline-dynamodb-streams/README.md
+++ b/packages/serverless-offline-dynamodb-streams/README.md
@@ -5,6 +5,7 @@ This Serverless-offline-dynamodb-streams plugin emulates AWS λ and DynamoDBStre
 *Features*:
 - [Serverless Webpack](https://github.com/serverless-heaven/serverless-webpack/) support.
 - DynamoDBStreams configurations: batchsize and startingPosition.
+- Checkpointing: read progress is persisted across `serverless offline` restarts, so previously processed records are not replayed (see [Checkpointing](#checkpointing)).
 
 ## Serverless Framework v4
 
@@ -79,3 +80,25 @@ functions:
           type: dynamodb
           tableName: myTable
 ```
+
+## Checkpointing
+
+<!-- #178 (jjohnson1994): persist read progress across offline restarts -->
+
+A local DynamoDB stream keeps its records for ~24h. Previously, every `serverless offline start` re-derived a `TRIM_HORIZON`/`LATEST` iterator and re-read every record the stream still retained, replaying already-processed events on each restart (and exhausting memory through unbounded re-reads — see [#178](https://github.com/CoorpAcademy/serverless-plugins/issues/178)).
+
+The plugin now persists the last processed sequence number per `(streamArn, shardId)` to a small JSON state file (default `.serverless-offline-dynamodb-streams` in the working directory) and, on the next start, resumes polling **after** that sequence number (`AFTER_SEQUENCE_NUMBER`) instead of replaying. The file is written best-effort: a read/write failure degrades gracefully to a cold start.
+
+Configure it under `custom.serverless-offline-dynamodb-streams`:
+
+```yml
+custom:
+  serverless-offline-dynamodb-streams:
+    checkpoint: true # default. `false` disables persistence (always start from startingPosition).
+    # checkpoint: .my-checkpoints.json # or a custom path for the state file
+```
+
+- `checkpoint: false` — opt out entirely; every start behaves as before, from the configured `startingPosition`.
+- `checkpoint: '<path>'` — use a custom state-file path (relative to the offline `location`, or absolute).
+
+> Add the state file to your `.gitignore` (e.g. `.serverless-offline-dynamodb-streams`).

--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -19,6 +19,7 @@
     "src/dynamodb-streams-event-definition.js",
     "src/resolve-arn.js",
     "src/filter-patterns.js",
+    "src/checkpoint-store.js",
     "NOTICE"
   ],
   "author": "Arthur Weber @godu",

--- a/packages/serverless-offline-dynamodb-streams/src/checkpoint-store.js
+++ b/packages/serverless-offline-dynamodb-streams/src/checkpoint-store.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+
+const {getOr, isEmpty, isNil, isPlainObject, set} = require('lodash/fp');
+
+// #178 (jjohnson1994): persist DynamoDB-stream read progress across `serverless offline`
+// restarts. Without it the readable is always created with `iterator: TRIM_HORIZON|
+// LATEST`, so each restart re-derives a fresh iterator and re-delivers records the
+// local stream still retains — replaying already-processed events and (per #178)
+// exhausting memory through unbounded re-reads.
+//
+// The store is a small JSON map: {<streamArn>: {<shardId>: <lastSequenceNumber>}}.
+// The transforms below are PURE (state + checkpoint -> next state; state -> startAfter);
+// the file read/write at the bottom is the only side effect and stays at the edges.
+
+const DEFAULT_CHECKPOINT_FILE = '.serverless-offline-dynamodb-streams';
+
+// ---------------------------------------------------------------------------
+// Pure helpers (state <-> sequence number) — exported for unit tests
+// ---------------------------------------------------------------------------
+
+// mergeCheckpoint(state, {streamArn, shardId, sequenceNumber}) -> next state.
+// A nil/empty sequence number is a no-op so a spurious checkpoint never clobbers
+// real progress. Non-mutating: builds a fresh nested map with `set`.
+const mergeCheckpoint = (state, {streamArn, shardId, sequenceNumber}) => {
+  if (isNil(sequenceNumber) || sequenceNumber === '') return state;
+  return set([streamArn, shardId], sequenceNumber, state);
+};
+
+// resolveStartAfter(state, {streamArn, shardId}) -> the saved sequence number to
+// resume *after*, or undefined on a cold start (unknown stream/shard).
+const resolveStartAfter = (state, {streamArn, shardId}) =>
+  getOr(undefined, [streamArn, shardId], state);
+
+// serializeCheckpointState(state) -> stable, human-diffable JSON.
+const serializeCheckpointState = state => JSON.stringify(state, null, 2);
+
+// parseCheckpointState(raw) -> state. Tolerant: malformed JSON, empty content or a
+// non-object payload all collapse to an empty state rather than throwing.
+const parseCheckpointState = raw => {
+  if (isNil(raw) || (typeof raw === 'string' && raw.trim() === '')) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : {};
+  } catch (err) {
+    return {};
+  }
+};
+
+// ---------------------------------------------------------------------------
+// I/O edges (thin side effects over the pure helpers)
+// ---------------------------------------------------------------------------
+
+const resolveCheckpointPath = (location, file = DEFAULT_CHECKPOINT_FILE) =>
+  path.isAbsolute(file) ? file : path.join(location || process.cwd(), file);
+
+// readCheckpointState(checkpointPath) -> state. A missing/unreadable file is a cold
+// start (empty state), never a crash.
+const readCheckpointState = checkpointPath => {
+  try {
+    return parseCheckpointState(fs.readFileSync(checkpointPath, 'utf8'));
+  } catch (err) {
+    return {};
+  }
+};
+
+// writeCheckpointState(checkpointPath, state) -> void. Best-effort: a persisted empty
+// state is skipped, and a write failure is swallowed (offline progress is a convenience,
+// not a guarantee — the caller logs it).
+const writeCheckpointState = (checkpointPath, state) => {
+  if (isEmpty(state)) return;
+  fs.writeFileSync(checkpointPath, serializeCheckpointState(state));
+};
+
+module.exports = {
+  DEFAULT_CHECKPOINT_FILE,
+  mergeCheckpoint,
+  resolveStartAfter,
+  serializeCheckpointState,
+  parseCheckpointState,
+  resolveCheckpointPath,
+  readCheckpointState,
+  writeCheckpointState
+};

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
@@ -8,6 +8,14 @@ const {normalizeLog} = require('./log');
 const DynamodbStreamsEventDefinition = require('./dynamodb-streams-event-definition');
 const DynamodbStreamsEvent = require('./dynamodb-streams-event');
 const {filterRecords} = require('./filter-patterns');
+const {
+  mergeCheckpoint,
+  resolveStartAfter,
+  readCheckpointState,
+  writeCheckpointState,
+  resolveCheckpointPath,
+  DEFAULT_CHECKPOINT_FILE
+} = require('./checkpoint-store');
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -19,6 +27,16 @@ const delay = timeout =>
 const assertStreamEnabled = (tableName, latestStreamArn) => {
   if (!latestStreamArn) throw new Error(`Table ${tableName} does not have streams enabled`);
   return latestStreamArn;
+};
+
+// #178 (jjohnson1994): build the readable's iterator options for one shard. When a sequence
+// number was checkpointed on a previous run, resume *after* it (the readable maps
+// `startAfter` -> AFTER_SEQUENCE_NUMBER) instead of re-deriving a TRIM_HORIZON/LATEST
+// iterator that would replay records the local stream still retains. `iterator` MUST be
+// omitted in that case — the readable prefers `iterator` over `startAfter`.
+const resolveIteratorOptions = (state, {streamArn, shardId, startingPosition}) => {
+  const startAfter = resolveStartAfter(state, {streamArn, shardId});
+  return startAfter ? {shardId, startAfter} : {shardId, iterator: startingPosition};
 };
 
 class DynamodbStreams {
@@ -34,6 +52,32 @@ class DynamodbStreams {
     this.streamsClient = new DynamodbStreamsClient(this.options);
 
     this.readables = [];
+
+    // #178 (jjohnson1994): resume from persisted read progress across offline restarts.
+    // Opt out with `custom.serverless-offline-dynamodb-streams.checkpoint: false`.
+    this.checkpointEnabled = options.checkpoint !== false;
+    this.checkpointPath = resolveCheckpointPath(
+      options.location,
+      typeof options.checkpoint === 'string' ? options.checkpoint : DEFAULT_CHECKPOINT_FILE
+    );
+    this.checkpointState = this.checkpointEnabled ? readCheckpointState(this.checkpointPath) : {};
+  }
+
+  // #178 (jjohnson1994): merge one shard's latest sequence number into the in-memory state and
+  // flush it to disk so the next `serverless offline start` resumes past it. Best-effort:
+  // a write failure is logged, never thrown (offline progress is a convenience).
+  _persistCheckpoint(streamArn, shardId, sequenceNumber) {
+    if (!this.checkpointEnabled) return;
+    this.checkpointState = mergeCheckpoint(this.checkpointState, {
+      streamArn,
+      shardId,
+      sequenceNumber
+    });
+    try {
+      writeCheckpointState(this.checkpointPath, this.checkpointState);
+    } catch (err) {
+      this.log.warning(`ddb-streams: failed to persist checkpoint: ${err.message}`);
+    }
   }
 
   create(events) {
@@ -101,14 +145,28 @@ class DynamodbStreams {
       .promise();
 
     shards.forEach(({ShardId: shardId}) => {
+      // #178 (jjohnson1994): on a warm restart resume past the last checkpointed sequence number
+      // (startAfter) instead of re-deriving a TRIM_HORIZON/LATEST iterator that replays
+      // already-processed records; on a cold start fall back to the configured position.
+      const iteratorOptions = resolveIteratorOptions(this.checkpointState, {
+        streamArn,
+        shardId,
+        startingPosition
+      });
+
       const readable = DynamodbStreamsReadable(
         this.streamsClient,
         streamArn,
         assign(dynamodbStreamsEvent, {
-          shardId,
-          limit: batchSize,
-          iterator: startingPosition
+          ...iteratorOptions,
+          limit: batchSize
         })
+      );
+
+      // #178 (jjohnson1994): persist progress as the readable advances. The readable emits
+      // `checkpoint` with the last SequenceNumber it passed downstream.
+      readable.on('checkpoint', sequenceNumber =>
+        this._persistCheckpoint(streamArn, shardId, sequenceNumber)
       );
 
       const writable = new Writable({
@@ -153,3 +211,4 @@ class DynamodbStreams {
 
 module.exports = DynamodbStreams;
 module.exports.assertStreamEnabled = assertStreamEnabled;
+module.exports.resolveIteratorOptions = resolveIteratorOptions;

--- a/packages/serverless-offline-dynamodb-streams/test/checkpoint-restart.integration.js
+++ b/packages/serverless-offline-dynamodb-streams/test/checkpoint-restart.integration.js
@@ -1,0 +1,138 @@
+// #178 (jjohnson1994): integration repro for "stop replaying past DynamoDB stream events on every
+// offline restart". Drives the real DynamodbStreams plugin class against local DynamoDB through a
+// stop -> recreate cycle and asserts records delivered in the first run are NOT redelivered after a
+// restart — only records written in between are. Requires a local DynamoDB at localhost:8000
+// (brought up by `npm run test:unit`), so it is gated to the docker-backed run via DDB_LOCAL.
+//
+// Run standalone:
+//   DDB_LOCAL=1 npx ava packages/serverless-offline-dynamodb-streams/test/checkpoint-restart.integration.js
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const test = require('ava');
+const DynamoDB = require('aws-sdk/clients/dynamodb');
+
+const DynamodbStreams = require('../src/dynamodb-streams');
+
+const ENDPOINT = process.env.DDB_LOCAL_ENDPOINT || 'http://localhost:8000';
+const REGION = 'eu-west-1';
+const skipUnlessLocal = process.env.DDB_LOCAL ? test.serial : test.serial.skip;
+
+const uuid = () => crypto.randomUUID();
+
+const delay = timeout =>
+  new Promise(resolve => {
+    setTimeout(resolve, timeout);
+  });
+
+// Sequentially run an async effect over a list without a raw loop (keeps the suite FP/lint-clean).
+const eachSeries = (items, effect) =>
+  items.reduce((previous, item) => previous.then(() => effect(item)), Promise.resolve());
+
+// Minimal stand-in for serverless-offline's Lambda registry: every runHandler() records the keys
+// of the records it was handed, so the test can assert exactly which records each run delivered.
+const makeLambdaStub = delivered => {
+  const lambdaFunction = {
+    event: null,
+    setEvent(event) {
+      this.event = event;
+    },
+    runHandler() {
+      this.event.Records.forEach(record => delivered.push(record.dynamodb.Keys.Id.S));
+      return Promise.resolve();
+    }
+  };
+  return {get: () => lambdaFunction};
+};
+
+const baseOptions = location => ({
+  region: REGION,
+  accountId: '000000000000',
+  accessKeyId: 'local',
+  secretAccessKey: 'local',
+  endpoint: ENDPOINT,
+  location
+});
+
+const putItem = (client, TableName, id) =>
+  client.putItem({Item: {Id: {S: id}}, TableName}).promise();
+
+const runOnce = async ({location, tableName, delivered, settle = 2500}) => {
+  const dynamodbStreams = new DynamodbStreams(
+    makeLambdaStub(delivered),
+    baseOptions(location),
+    undefined
+  );
+  await dynamodbStreams.create([{functionKey: 'handler', dynamodbStreams: {tableName}}]);
+  dynamodbStreams.start();
+  await delay(settle);
+  await dynamodbStreams.stop();
+  return dynamodbStreams;
+};
+
+skipUnlessLocal(
+  'does not redeliver already-checkpointed records after an offline restart (#178)',
+  async t => {
+    const client = new DynamoDB(baseOptions());
+    const tableName = `repro-${uuid()}`;
+    const location = fs.mkdtempSync(path.join(os.tmpdir(), 'ddb-checkpoint-'));
+
+    await client
+      .createTable({
+        TableName: tableName,
+        AttributeDefinitions: [{AttributeName: 'Id', AttributeType: 'S'}],
+        KeySchema: [{AttributeName: 'Id', KeyType: 'HASH'}],
+        StreamSpecification: {StreamEnabled: true, StreamViewType: 'NEW_AND_OLD_IMAGES'},
+        ProvisionedThroughput: {ReadCapacityUnits: 1, WriteCapacityUnits: 1}
+      })
+      .promise();
+    await client.waitFor('tableExists', {TableName: tableName}).promise();
+
+    // First run: write 3 records, let them be delivered, then stop (persisting the checkpoint).
+    const firstBatch = [uuid(), uuid(), uuid()];
+    const deliveredFirst = [];
+    // Start the reader first so a TRIM_HORIZON cold start has the shard iterator before writes.
+    const first = new DynamodbStreams(
+      makeLambdaStub(deliveredFirst),
+      baseOptions(location),
+      undefined
+    );
+    await first.create([{functionKey: 'handler', dynamodbStreams: {tableName}}]);
+    first.start();
+    await delay(500);
+    await eachSeries(firstBatch, id => putItem(client, tableName, id));
+    await delay(2500);
+    await first.stop();
+
+    t.deepEqual(
+      [...deliveredFirst].sort(),
+      [...firstBatch].sort(),
+      'first run delivers exactly the first batch'
+    );
+
+    // The checkpoint file must now exist with a saved sequence number for the shard.
+    const stateFile = path.join(location, '.serverless-offline-dynamodb-streams');
+    t.true(fs.existsSync(stateFile), 'a checkpoint state file is written on stop');
+
+    // Write more records AFTER the first run stopped — these are the only ones the restart should see.
+    const secondBatch = [uuid(), uuid()];
+    await eachSeries(secondBatch, id => putItem(client, tableName, id));
+
+    // Restart: a brand-new instance reads the persisted checkpoint and must resume PAST the first
+    // batch — delivering only the second batch, never replaying the already-processed records.
+    const deliveredSecond = [];
+    await runOnce({location, tableName, delivered: deliveredSecond, settle: 3000});
+
+    t.deepEqual(
+      [...deliveredSecond].sort(),
+      [...secondBatch].sort(),
+      'restart delivers only the records written after the checkpoint, not the replayed first batch'
+    );
+    firstBatch.forEach(id =>
+      t.false(deliveredSecond.includes(id), `record ${id} must not be redelivered`)
+    );
+  }
+);

--- a/packages/serverless-offline-dynamodb-streams/test/checkpoint-store.js
+++ b/packages/serverless-offline-dynamodb-streams/test/checkpoint-store.js
@@ -1,0 +1,123 @@
+const test = require('ava');
+
+const {
+  mergeCheckpoint,
+  resolveStartAfter,
+  serializeCheckpointState,
+  parseCheckpointState
+} = require('../src/checkpoint-store');
+
+// ---------------------------------------------------------------------------
+// mergeCheckpoint (#178 jjohnson1994) — state + new (streamArn, shardId, seq) -> next state
+// ---------------------------------------------------------------------------
+
+const STREAM_A = 'arn:aws:dynamodb:eu-west-1:000000000000:table/myTable/stream/2024';
+const STREAM_B = 'arn:aws:dynamodb:eu-west-1:000000000000:table/orders/stream/2024';
+
+test('mergeCheckpoint writes the sequence number under (streamArn, shardId) into an empty state', t => {
+  const next = mergeCheckpoint(
+    {},
+    {streamArn: STREAM_A, shardId: 'shard-0', sequenceNumber: '111'}
+  );
+
+  t.deepEqual(next, {[STREAM_A]: {'shard-0': '111'}});
+});
+
+test('mergeCheckpoint overwrites the previous sequence number for the same (streamArn, shardId)', t => {
+  const state = {[STREAM_A]: {'shard-0': '111'}};
+  const next = mergeCheckpoint(state, {
+    streamArn: STREAM_A,
+    shardId: 'shard-0',
+    sequenceNumber: '222'
+  });
+
+  t.deepEqual(next, {[STREAM_A]: {'shard-0': '222'}});
+});
+
+test('mergeCheckpoint keeps sibling shards and sibling streams untouched', t => {
+  const state = {
+    [STREAM_A]: {'shard-0': '111', 'shard-1': '999'},
+    [STREAM_B]: {'shard-0': '500'}
+  };
+  const next = mergeCheckpoint(state, {
+    streamArn: STREAM_A,
+    shardId: 'shard-0',
+    sequenceNumber: '222'
+  });
+
+  t.deepEqual(next, {
+    [STREAM_A]: {'shard-0': '222', 'shard-1': '999'},
+    [STREAM_B]: {'shard-0': '500'}
+  });
+});
+
+test('mergeCheckpoint does not mutate the input state', t => {
+  const state = {[STREAM_A]: {'shard-0': '111'}};
+  const before = JSON.parse(JSON.stringify(state));
+
+  mergeCheckpoint(state, {streamArn: STREAM_A, shardId: 'shard-0', sequenceNumber: '222'});
+
+  t.deepEqual(state, before);
+});
+
+test('mergeCheckpoint ignores a nil/empty sequence number (no spurious checkpoint)', t => {
+  const state = {[STREAM_A]: {'shard-0': '111'}};
+
+  t.deepEqual(
+    mergeCheckpoint(state, {streamArn: STREAM_A, shardId: 'shard-0', sequenceNumber: undefined}),
+    state
+  );
+  t.deepEqual(
+    mergeCheckpoint(state, {streamArn: STREAM_A, shardId: 'shard-0', sequenceNumber: null}),
+    state
+  );
+  t.deepEqual(
+    mergeCheckpoint(state, {streamArn: STREAM_A, shardId: 'shard-0', sequenceNumber: ''}),
+    state
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveStartAfter (#178 jjohnson1994) — state -> the saved sequence to resume past
+// ---------------------------------------------------------------------------
+
+test('resolveStartAfter returns the saved sequence number for a known (streamArn, shardId)', t => {
+  const state = {[STREAM_A]: {'shard-0': '111'}};
+  t.is(resolveStartAfter(state, {streamArn: STREAM_A, shardId: 'shard-0'}), '111');
+});
+
+test('resolveStartAfter returns undefined for an unknown stream or shard (cold start)', t => {
+  const state = {[STREAM_A]: {'shard-0': '111'}};
+  t.is(resolveStartAfter(state, {streamArn: STREAM_A, shardId: 'shard-1'}), undefined);
+  t.is(resolveStartAfter(state, {streamArn: STREAM_B, shardId: 'shard-0'}), undefined);
+  t.is(resolveStartAfter({}, {streamArn: STREAM_A, shardId: 'shard-0'}), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// serialize / parse round-trip (#178 jjohnson1994)
+// ---------------------------------------------------------------------------
+
+test('serializeCheckpointState + parseCheckpointState round-trips a state map', t => {
+  const state = {[STREAM_A]: {'shard-0': '222'}, [STREAM_B]: {'shard-0': '500'}};
+  t.deepEqual(parseCheckpointState(serializeCheckpointState(state)), state);
+});
+
+test('parseCheckpointState tolerates malformed/empty content by returning an empty state', t => {
+  t.deepEqual(parseCheckpointState(''), {});
+  t.deepEqual(parseCheckpointState('   '), {});
+  t.deepEqual(parseCheckpointState('not json'), {});
+  t.deepEqual(parseCheckpointState(undefined), {});
+  t.deepEqual(parseCheckpointState(null), {});
+});
+
+test('parseCheckpointState coerces a non-object JSON payload to an empty state', t => {
+  t.deepEqual(parseCheckpointState('123'), {});
+  t.deepEqual(parseCheckpointState('"a string"'), {});
+  t.deepEqual(parseCheckpointState('[1,2,3]'), {});
+  t.deepEqual(parseCheckpointState('null'), {});
+});
+
+test('serializeCheckpointState produces stable, human-diffable JSON', t => {
+  const state = {[STREAM_A]: {'shard-0': '222'}};
+  t.is(serializeCheckpointState(state), JSON.stringify(state, null, 2));
+});

--- a/packages/serverless-offline-dynamodb-streams/test/index.js
+++ b/packages/serverless-offline-dynamodb-streams/test/index.js
@@ -6,7 +6,7 @@ const test = require('ava');
 const {defaultLog, normalizeLog} = require('../src/log');
 const DynamodbStreamsEvent = require('../src/dynamodb-streams-event');
 const DynamodbStreamsEventDefinition = require('../src/dynamodb-streams-event-definition');
-const {assertStreamEnabled} = require('../src/dynamodb-streams');
+const {assertStreamEnabled, resolveIteratorOptions} = require('../src/dynamodb-streams');
 const {resolveTableName} = require('../src/resolve-arn');
 const {recordMatchesFilterPatterns, filterRecords} = require('../src/filter-patterns');
 
@@ -123,6 +123,58 @@ test('assertStreamEnabled throws a clear error when LatestStreamArn is null/empt
     t.throws(() => assertStreamEnabled('orders', '')).message,
     'Table orders does not have streams enabled'
   );
+});
+
+// --- resolveIteratorOptions (#178 jjohnson1994) -------------------------------
+
+const STREAM_ARN = 'arn:aws:dynamodb:eu-west-1:000000000000:table/myTable/stream/2024';
+
+test('resolveIteratorOptions resumes startAfter the saved sequence number, omitting iterator (#178)', t => {
+  const state = {[STREAM_ARN]: {'shard-0': '111'}};
+  t.deepEqual(
+    resolveIteratorOptions(state, {
+      streamArn: STREAM_ARN,
+      shardId: 'shard-0',
+      startingPosition: 'LATEST'
+    }),
+    {shardId: 'shard-0', startAfter: '111'}
+  );
+});
+
+test('resolveIteratorOptions falls back to the configured iterator on a cold start (#178)', t => {
+  t.deepEqual(
+    resolveIteratorOptions(
+      {},
+      {streamArn: STREAM_ARN, shardId: 'shard-0', startingPosition: 'TRIM_HORIZON'}
+    ),
+    {shardId: 'shard-0', iterator: 'TRIM_HORIZON'}
+  );
+});
+
+test('resolveIteratorOptions falls back per-shard when only a sibling shard was checkpointed (#178)', t => {
+  const state = {[STREAM_ARN]: {'shard-0': '111'}};
+  t.deepEqual(
+    resolveIteratorOptions(state, {
+      streamArn: STREAM_ARN,
+      shardId: 'shard-1',
+      startingPosition: 'LATEST'
+    }),
+    {shardId: 'shard-1', iterator: 'LATEST'}
+  );
+});
+
+test('resolveIteratorOptions never sets both iterator and startAfter (readable prefers iterator)', t => {
+  const resumed = resolveIteratorOptions(
+    {[STREAM_ARN]: {'shard-0': '111'}},
+    {streamArn: STREAM_ARN, shardId: 'shard-0', startingPosition: 'LATEST'}
+  );
+  const cold = resolveIteratorOptions(
+    {},
+    {streamArn: STREAM_ARN, shardId: 'shard-0', startingPosition: 'LATEST'}
+  );
+
+  t.is(resumed.iterator, undefined);
+  t.is(cold.startAfter, undefined);
 });
 
 // --- DynamodbStreamsEventDefinition normalizer --------------------------


### PR DESCRIPTION
…across offline restarts (#178)

Previously the readable was always created with `iterator: TRIM_HORIZON|LATEST`, so every `serverless offline start` re-derived a fresh iterator and re-read every record the local stream still retained — replaying already-processed events and exhausting memory through unbounded re-reads (#178).

The plugin now consumes the readable's `checkpoint` event and persists the last SequenceNumber per (streamArn, shardId) to a small local JSON state file (default `.serverless-offline-dynamodb-streams`). On startup it resolves the saved sequence number and resumes polling via `startAfter` (AFTER_SEQUENCE_NUMBER) instead of replaying. Opt out with `custom.serverless-offline-dynamodb-streams.checkpoint: false`, or set a custom path with `checkpoint: '<path>'`.

The read/merge/serialize transforms are pure exported helpers (checkpoint-store.js, plus resolveIteratorOptions in dynamodb-streams.js) with AVA unit coverage; the file I/O is a thin side effect at the edges. Adds an integration repro (checkpoint-restart.integration.js, gated behind DDB_LOCAL) asserting that records delivered in a first run are not redelivered after a restart.