### PR TITLE
fix(serverless-offline-dynamodb-streams): migrate from aws-sdk v2 to …

### DIFF
--- a/packages/dynamodb-streams-readable/package.json
+++ b/packages/dynamodb-streams-readable/package.json
@@ -25,6 +25,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.621.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.621.0",
     "uuid": "^9.0.0"
   },
   "keywords": [

--- a/packages/dynamodb-streams-readable/test/index.js
+++ b/packages/dynamodb-streams-readable/test/index.js
@@ -1,8 +1,38 @@
 const test = require('ava');
 const {v4: uuid} = require('uuid');
-const DynamoDB = require('aws-sdk/clients/dynamodb');
-const DynamoDBStreams = require('aws-sdk/clients/dynamodbstreams');
+const {
+  DynamoDBClient,
+  CreateTableCommand,
+  BatchWriteItemCommand,
+  ScanCommand
+} = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBStreamsClient,
+  DescribeStreamCommand,
+  GetShardIteratorCommand,
+  GetRecordsCommand
+} = require('@aws-sdk/client-dynamodb-streams');
 const DynamoDBStreamReadable = require('..');
+
+// #248 (EdgarOrtegaRamirez): migrated the test off aws-sdk v2 to @aws-sdk v3. DynamoDBStreamReadable
+// consumes the v2 *callback* contract (`client.getRecords(params, cb)`), so wrap the v3 streams
+// client's promise-based `send(command)` back into that trio — the same adapter shape the consumer
+// package ships in production.
+const toCallbackStreamsClient = client => {
+  const method = Command => (params, callback) =>
+    client.send(new Command(params)).then(data => callback(null, data), callback);
+  return {
+    getShardIterator: method(GetShardIteratorCommand),
+    describeStream: method(DescribeStreamCommand),
+    getRecords: method(GetRecordsCommand)
+  };
+};
+
+const LOCAL_CONFIG = {
+  credentials: {accessKeyId: 'local', secretAccessKey: 'local'},
+  endpoint: 'http://localhost:8000',
+  region: 'eu-west-1'
+};
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -10,29 +40,19 @@ const delay = timeout =>
   });
 
 const batchWriteItem = (dynamodb, tableName, items) =>
-  dynamodb
-    .batchWriteItem({
+  dynamodb.send(
+    new BatchWriteItemCommand({
       RequestItems: {
         [tableName]: items.map(document => ({
           PutRequest: document
         }))
       }
     })
-    .promise();
+  );
 
 test.before(t => {
-  t.context.dynamodb = new DynamoDB({
-    accessKeyId: 'local',
-    secretAccessKey: 'local',
-    endpoint: 'http://localhost:8000',
-    region: 'eu-west-1'
-  });
-  t.context.dynamodbstreams = new DynamoDBStreams({
-    accessKeyId: 'local',
-    secretAccessKey: 'local',
-    endpoint: 'http://localhost:8000',
-    region: 'eu-west-1'
-  });
+  t.context.dynamodb = new DynamoDBClient(LOCAL_CONFIG);
+  t.context.dynamodbstreams = toCallbackStreamsClient(new DynamoDBStreamsClient(LOCAL_CONFIG));
 });
 
 test.beforeEach(async t => {
@@ -41,8 +61,8 @@ test.beforeEach(async t => {
   const tableName = uuid();
   t.context.tableName = tableName;
 
-  const table = await dynamodb
-    .createTable({
+  const table = await dynamodb.send(
+    new CreateTableCommand({
       TableName: tableName,
       AttributeDefinitions: [
         {
@@ -65,7 +85,7 @@ test.beforeEach(async t => {
         WriteCapacityUnits: 1
       }
     })
-    .promise();
+  );
 
   t.context.table = table;
 });
@@ -90,15 +110,13 @@ test.serial('reads records that already exist', async t => {
 
   await batchWriteItem(dynamodb, tableName, documents);
 
-  t.deepEqual(
-    await dynamodb
-      .scan({
-        TableName: tableName,
-        Select: 'COUNT'
-      })
-      .promise(),
-    {Count: documents.length, ScannedCount: documents.length}
+  const {Count, ScannedCount} = await dynamodb.send(
+    new ScanCommand({
+      TableName: tableName,
+      Select: 'COUNT'
+    })
   );
+  t.deepEqual({Count, ScannedCount}, {Count: documents.length, ScannedCount: documents.length});
 
   const readable = DynamoDBStreamReadable(dynamodbstreams, LatestStreamArn, {readInterval: 1});
 

--- a/packages/serverless-offline-dynamodb-streams/README.md
+++ b/packages/serverless-offline-dynamodb-streams/README.md
@@ -10,6 +10,10 @@ This Serverless-offline-dynamodb-streams plugin emulates AWS λ and DynamoDBStre
 
 This plugin is compatible with both Serverless Framework **v3** and **v4**. Serverless v4 removed the global `@serverless/utils/log` and `serverless.cli.log` APIs; the plugin now reads the structured logger from the third constructor argument injected by the framework (`{log}`) and falls back to `console` when run standalone, so no configuration change is required on either version.
 
+## AWS SDK v3
+
+As of this release the plugin uses the modular [AWS SDK for JavaScript **v3**](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/welcome.html) (`@aws-sdk/client-dynamodb` and `@aws-sdk/client-dynamodb-streams`) instead of the end-of-support `aws-sdk` v2 package, which removes the AWS-SDK-v2 maintenance-mode warning ([#248](https://github.com/CoorpAcademy/serverless-plugins/issues/248)). The plugin options are unchanged: it still accepts the flat `region`/`endpoint`/`accessKeyId`/`secretAccessKey` keys and normalizes them into the v3 client config internally, so existing `custom.serverless-offline-dynamodb-streams` configuration keeps working as-is.
+
 ## Installation
 
 First, add `serverless-offline-dynamodb-streams` to your project:

--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -15,6 +15,8 @@
     "src/index.js",
     "src/log.js",
     "src/dynamodb-streams.js",
+    "src/dynamodb-streams-client.js",
+    "src/aws-client.js",
     "src/dynamodb-streams-event.js",
     "src/dynamodb-streams-event-definition.js",
     "src/resolve-arn.js",
@@ -30,7 +32,8 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-dynamodb": "^3.621.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.621.0",
     "dynamodb-streams-readable": "^3.0.0",
     "lodash": "^4.17.21",
     "serverless-offline-eventbridge": "^1.0.0"

--- a/packages/serverless-offline-dynamodb-streams/src/aws-client.js
+++ b/packages/serverless-offline-dynamodb-streams/src/aws-client.js
@@ -1,0 +1,31 @@
+const {getOr, isNil, omitBy, pick} = require('lodash/fp');
+
+// #248 (EdgarOrtegaRamirez): the plugin printed the AWS-SDK-v2 maintenance-mode warning because it
+// imported `aws-sdk/clients/dynamodb(streams)`. We migrated to `@aws-sdk/client-dynamodb(-streams)`
+// v3. The Serverless config still hands us a *flat* v2-style options bag
+// ({region, endpoint, accessKeyId, secretAccessKey, ...}); v3 wants `region`/`endpoint` at the top
+// level and `accessKeyId`/`secretAccessKey` nested under `credentials`. `toClientConfig` is the pure
+// boundary that normalizes the former into the latter.
+
+const omitNil = omitBy(isNil);
+
+// Build the nested v3 `credentials` from the flat v2 keys. Only emitted when an accessKeyId is
+// present; the secret defaults to the accessKeyId so a local emulator (dynamodb-local) — which does
+// not verify the signature — still receives a non-empty secret, mirroring the v2 behaviour where the
+// flat keys were forwarded verbatim. With no accessKeyId we fall through to the default credential
+// chain (no `credentials` key), exactly as v2 did when none were configured.
+const toCredentials = options => {
+  const accessKeyId = getOr(undefined, 'accessKeyId', options);
+  if (isNil(accessKeyId)) return undefined;
+  const secretAccessKey = getOr(accessKeyId, 'secretAccessKey', options);
+  const sessionToken = getOr(undefined, 'sessionToken', options);
+  return omitNil({accessKeyId, secretAccessKey, sessionToken});
+};
+
+const toClientConfig = (options = {}) => {
+  const base = pick(['region', 'endpoint'], options);
+  const credentials = toCredentials(options);
+  return omitNil({...base, credentials});
+};
+
+module.exports = {toClientConfig, toCredentials};

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-client.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams-client.js
@@ -1,0 +1,46 @@
+const {
+  DynamoDBStreamsClient,
+  DescribeStreamCommand,
+  GetShardIteratorCommand,
+  GetRecordsCommand
+} = require('@aws-sdk/client-dynamodb-streams');
+
+const {toClientConfig} = require('./aws-client');
+
+// #248 (EdgarOrtegaRamirez): `dynamodb-streams-readable` consumes its client through the AWS-SDK-v2
+// *callback* contract — `client.getShardIterator(params, cb)`, `client.describeStream(params, cb)`,
+// `client.getRecords(params, cb)`. AWS-SDK v3 only exposes the promise-based `client.send(command)`.
+// Rather than rewrite the readable (and risk its battle-tested pure helpers), we adapt the v3 client
+// to the v2 callback surface with this thin shim. The v3 response (minus `$metadata`) carries the
+// same fields the readable reads (`ShardIterator`, `StreamDescription.Shards`, `Records`,
+// `NextShardIterator`), so its pure helpers — selectShardId / isRecoverableIteratorError /
+// nextRetryState / shouldKeepPolling / canRead — keep passing untouched.
+
+// Turn `client.send(new Command(params))` (a Promise) into a v2-style `(params, cb)` method.
+const toCallbackMethod = (client, Command) => (params, callback) => {
+  client
+    .send(new Command(params))
+    .then(data => callback(null, data))
+    // v3 surfaces the AWS error type via `err.name` (e.g. ExpiredIteratorException), which is exactly
+    // what the readable's isRecoverableIteratorError inspects — so the recovery path is preserved.
+    .catch(callback);
+};
+
+// Wrap a v3 DynamoDBStreamsClient in the trio of callback methods the readable expects. Exported pure
+// so it can be unit-tested against a fake `{send}` without any network or real SDK client.
+const toCallbackStreamsClient = client => ({
+  getShardIterator: toCallbackMethod(client, GetShardIteratorCommand),
+  describeStream: toCallbackMethod(client, DescribeStreamCommand),
+  getRecords: toCallbackMethod(client, GetRecordsCommand)
+});
+
+// Construct a real v3 streams client from the flat Serverless options, already adapted to the v2
+// callback contract — the single value `dynamodb-streams.js` hands to DynamoDBStreamReadable.
+const createCallbackStreamsClient = options =>
+  toCallbackStreamsClient(new DynamoDBStreamsClient(toClientConfig(options)));
+
+module.exports = {
+  toCallbackMethod,
+  toCallbackStreamsClient,
+  createCallbackStreamsClient
+};

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
@@ -1,13 +1,26 @@
 const {Writable} = require('stream');
-const DynamodbClient = require('aws-sdk/clients/dynamodb');
-const DynamodbStreamsClient = require('aws-sdk/clients/dynamodbstreams');
+// #248 (EdgarOrtegaRamirez): migrated off aws-sdk v2 (`aws-sdk/clients/dynamodb(streams)`), which
+// emitted the maintenance-mode warning, to the modular @aws-sdk v3 clients/commands/waiters.
+const {
+  DynamoDBClient,
+  DescribeTableCommand,
+  waitUntilTableExists
+} = require('@aws-sdk/client-dynamodb');
+const {DynamoDBStreamsClient, DescribeStreamCommand} = require('@aws-sdk/client-dynamodb-streams');
 const DynamodbStreamsReadable = require('dynamodb-streams-readable');
 const {assign, isEmpty} = require('lodash/fp');
 
 const {normalizeLog} = require('./log');
+const {toClientConfig} = require('./aws-client');
+const {toCallbackStreamsClient} = require('./dynamodb-streams-client');
 const DynamodbStreamsEventDefinition = require('./dynamodb-streams-event-definition');
 const DynamodbStreamsEvent = require('./dynamodb-streams-event');
 const {filterRecords} = require('./filter-patterns');
+
+// Bound the v3 `waitUntilTableExists` waiter so a not-yet-created table makes the waiter reject
+// promptly; our recursive retry in `_describeTable` then re-arms it (preserving the v2 behaviour of
+// blocking until the table appears) instead of one call hanging forever.
+const TABLE_EXISTS_MAX_WAIT_SECONDS = 60;
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -30,8 +43,13 @@ class DynamodbStreams {
     this.options = options;
     this.log = normalizeLog(log);
 
-    this.client = new DynamodbClient(this.options);
-    this.streamsClient = new DynamodbStreamsClient(this.options);
+    // #248: v3 wants region/endpoint at the top level and credentials nested — `toClientConfig`
+    // normalizes the flat v2-style options bag once at this boundary.
+    const clientConfig = toClientConfig(this.options);
+    this.client = new DynamoDBClient(clientConfig);
+    this.streamsClient = new DynamoDBStreamsClient(clientConfig);
+    // The readable consumes the v2 callback contract; adapt the v3 streams client to it.
+    this.streamsCallbackClient = toCallbackStreamsClient(this.streamsClient);
 
     this.readables = [];
   }
@@ -62,12 +80,13 @@ class DynamodbStreams {
 
   async _describeTable(tableName) {
     try {
-      await this.client.waitFor('tableExists', {TableName: tableName}).promise();
-      return await this.client
-        .describeTable({
-          TableName: tableName
-        })
-        .promise();
+      // #248: v3 replaces v2 `waitFor('tableExists')` with the standalone `waitUntilTableExists`
+      // waiter and `describeTable().promise()` with `client.send(new DescribeTableCommand(...))`.
+      await waitUntilTableExists(
+        {client: this.client, maxWaitTime: TABLE_EXISTS_MAX_WAIT_SECONDS},
+        {TableName: tableName}
+      );
+      return await this.client.send(new DescribeTableCommand({TableName: tableName}));
     } catch (err) {
       return this._describeTable(tableName);
     }
@@ -94,15 +113,13 @@ class DynamodbStreams {
 
     const {
       StreamDescription: {Shards: shards}
-    } = await this.streamsClient
-      .describeStream({
-        StreamArn: streamArn
-      })
-      .promise();
+    } = await this.streamsClient.send(new DescribeStreamCommand({StreamArn: streamArn}));
 
     shards.forEach(({ShardId: shardId}) => {
       const readable = DynamodbStreamsReadable(
-        this.streamsClient,
+        // #248: the readable still speaks the v2 callback API; hand it the adapter, not the raw v3
+        // client (which only exposes `send`).
+        this.streamsCallbackClient,
         streamArn,
         assign(dynamodbStreamsEvent, {
           shardId,

--- a/packages/serverless-offline-dynamodb-streams/test/index.js
+++ b/packages/serverless-offline-dynamodb-streams/test/index.js
@@ -3,12 +3,15 @@ const path = require('path');
 
 const test = require('ava');
 
+const DynamodbStreamsReadable = require('dynamodb-streams-readable');
 const {defaultLog, normalizeLog} = require('../src/log');
 const DynamodbStreamsEvent = require('../src/dynamodb-streams-event');
 const DynamodbStreamsEventDefinition = require('../src/dynamodb-streams-event-definition');
 const {assertStreamEnabled} = require('../src/dynamodb-streams');
 const {resolveTableName} = require('../src/resolve-arn');
 const {recordMatchesFilterPatterns, filterRecords} = require('../src/filter-patterns');
+const {toClientConfig, toCredentials} = require('../src/aws-client');
+const {toCallbackMethod, toCallbackStreamsClient} = require('../src/dynamodb-streams-client');
 
 const LOG_LEVELS = ['debug', 'info', 'notice', 'warning', 'error', 'success'];
 
@@ -345,4 +348,206 @@ test('recordMatchesFilterPatterns/filterRecords do not mutate inputs', t => {
   filterRecords(patterns, records);
   t.deepEqual(patterns, patternsBefore);
   t.deepEqual(records, recordsBefore);
+});
+
+// ---------------------------------------------------------------------------
+// aws-sdk v3 migration (#248 EdgarOrtegaRamirez)
+// ---------------------------------------------------------------------------
+// Repro for #248: the plugin imported aws-sdk v2 (`aws-sdk/clients/dynamodb(streams)`), which printed
+// the maintenance-mode warning. These guards FAIL on the pre-migration source (which `require`d
+// aws-sdk v2 and called `.promise()` / `waitFor`) and PASS once the package speaks @aws-sdk v3.
+
+// Scan executable code only: drop `//` line comments and `/* */` block comments so the guards match
+// real imports/calls, not the issue references the migration leaves in the comments.
+const stripComments = source =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+test('src no longer imports aws-sdk v2 anywhere (#248)', t => {
+  ['dynamodb-streams.js', 'aws-client.js', 'dynamodb-streams-client.js'].forEach(file => {
+    const code = stripComments(readSource(file));
+    t.false(code.includes("require('aws-sdk"), `${file} must not require aws-sdk v2`);
+    t.false(/aws-sdk\/clients\//.test(code), `${file} must not import an aws-sdk v2 client`);
+  });
+});
+
+test('dynamodb-streams.js uses @aws-sdk v3 clients/commands/waiter, not v2 .promise()/waitFor (#248)', t => {
+  const code = stripComments(readSource('dynamodb-streams.js'));
+
+  t.true(code.includes("@aws-sdk/client-dynamodb'"));
+  t.true(code.includes('@aws-sdk/client-dynamodb-streams'));
+  t.true(code.includes('waitUntilTableExists'));
+  t.true(code.includes('DescribeTableCommand'));
+  t.true(code.includes('DescribeStreamCommand'));
+  // the v2-only surfaces named in the issue are gone
+  t.false(code.includes('.promise()'));
+  t.false(code.includes('waitFor('));
+});
+
+test('package.json depends on @aws-sdk v3 clients and dropped aws-sdk v2 (#248)', t => {
+  const pkg = JSON.parse(readSource('../package.json'));
+  t.truthy(pkg.dependencies['@aws-sdk/client-dynamodb']);
+  t.truthy(pkg.dependencies['@aws-sdk/client-dynamodb-streams']);
+  t.is(pkg.dependencies['aws-sdk'], undefined);
+});
+
+// --- toClientConfig: flat v2 options -> nested v3 config -------------------
+
+test('toClientConfig nests flat credentials and passes through region/endpoint', t => {
+  t.deepEqual(
+    toClientConfig({
+      region: 'eu-west-1',
+      endpoint: 'http://localhost:8000',
+      accessKeyId: 'local',
+      secretAccessKey: 'secret'
+    }),
+    {
+      region: 'eu-west-1',
+      endpoint: 'http://localhost:8000',
+      credentials: {accessKeyId: 'local', secretAccessKey: 'secret'}
+    }
+  );
+});
+
+test('toClientConfig defaults a missing secretAccessKey to the accessKeyId (local-emulator parity)', t => {
+  t.deepEqual(toClientConfig({region: 'eu-west-1', accessKeyId: '000000000000'}), {
+    region: 'eu-west-1',
+    credentials: {accessKeyId: '000000000000', secretAccessKey: '000000000000'}
+  });
+});
+
+test('toClientConfig forwards a sessionToken when present', t => {
+  t.deepEqual(
+    toClientConfig({
+      region: 'eu-west-1',
+      accessKeyId: 'a',
+      secretAccessKey: 'b',
+      sessionToken: 't'
+    }),
+    {region: 'eu-west-1', credentials: {accessKeyId: 'a', secretAccessKey: 'b', sessionToken: 't'}}
+  );
+});
+
+test('toClientConfig omits credentials entirely when no accessKeyId is configured', t => {
+  t.deepEqual(toClientConfig({region: 'eu-west-1', endpoint: 'http://localhost:8000'}), {
+    region: 'eu-west-1',
+    endpoint: 'http://localhost:8000'
+  });
+  t.is(toCredentials({region: 'eu-west-1'}), undefined);
+});
+
+test('toClientConfig drops unknown v2 keys (only region/endpoint/credentials reach v3)', t => {
+  const config = toClientConfig({
+    region: 'eu-west-1',
+    accessKeyId: 'a',
+    secretAccessKey: 'b',
+    accountId: '000000000000',
+    stage: 'dev',
+    location: '.'
+  });
+  t.deepEqual(Object.keys(config).sort(), ['credentials', 'region']);
+});
+
+test('toClientConfig does not mutate its input', t => {
+  const options = {region: 'eu-west-1', accessKeyId: 'a', secretAccessKey: 'b'};
+  const before = JSON.parse(JSON.stringify(options));
+  toClientConfig(options);
+  t.deepEqual(options, before);
+});
+
+test('toClientConfig() with no argument is safe', t => {
+  t.deepEqual(toClientConfig(), {});
+});
+
+// --- toCallbackMethod / toCallbackStreamsClient: v3 send() -> v2 callback ---
+
+test('toCallbackMethod turns a resolved send() into callback(null, data)', async t => {
+  const data = {ShardIterator: 'it-1'};
+  const fakeClient = {send: () => Promise.resolve(data)};
+  const method = toCallbackMethod(fakeClient, function Cmd(params) {
+    this.input = params;
+  });
+
+  const result = await new Promise((resolve, reject) => {
+    method({ShardId: 's'}, (err, d) => (err ? reject(err) : resolve(d)));
+  });
+  t.is(result, data);
+});
+
+test('toCallbackMethod wraps params in the v3 Command and routes a rejection to callback(err)', async t => {
+  let received;
+  const boom = Object.assign(new Error('nope'), {name: 'ExpiredIteratorException'});
+  const fakeClient = {
+    send: command => {
+      received = command;
+      return Promise.reject(boom);
+    }
+  };
+  const method = toCallbackMethod(fakeClient, function Cmd(params) {
+    this.input = params;
+  });
+
+  const err = await new Promise(resolve => {
+    method({ShardIterator: 'it'}, e => resolve(e));
+  });
+  // err.name is exactly what dynamodb-streams-readable's isRecoverableIteratorError inspects
+  t.is(err, boom);
+  t.is(err.name, 'ExpiredIteratorException');
+  t.deepEqual(received.input, {ShardIterator: 'it'});
+});
+
+test('toCallbackStreamsClient exposes the v2 callback trio over a v3 send() client', t => {
+  const client = toCallbackStreamsClient({send: () => Promise.resolve({})});
+  t.is(typeof client.getShardIterator, 'function');
+  t.is(typeof client.describeStream, 'function');
+  t.is(typeof client.getRecords, 'function');
+});
+
+// --- end-to-end shim: DynamoDBStreamReadable drives the v3-backed adapter ---
+// Proves the readable's pure helpers keep working against the shim: a fake v3 `send()` returns one
+// batch then drains; DynamoDBStreamReadable must emit exactly that batch and then `end`.
+
+test('DynamoDBStreamReadable reads a record set through the v3->callback shim, then ends (#248)', t => {
+  const record = {dynamodb: {Keys: {Id: {S: '1'}}, SequenceNumber: '111'}};
+
+  // Minimal fake v3 streams client: describeStream -> one shard; getShardIterator -> a token;
+  // getRecords -> the batch once, then an empty drain.
+  const responsesFor = name =>
+    ({
+      DescribeStreamCommand: {StreamDescription: {Shards: [{ShardId: 'shard-1'}]}},
+      GetShardIteratorCommand: {ShardIterator: 'iter-1'}
+    }[name]);
+
+  let served = false;
+  const fakeV3Client = {
+    send: command => {
+      const name = command.constructor.name;
+      if (name === 'GetRecordsCommand') {
+        if (served) return Promise.resolve({Records: [], NextShardIterator: null});
+        served = true;
+        return Promise.resolve({Records: [record], NextShardIterator: 'iter-2'});
+      }
+      return Promise.resolve(responsesFor(name));
+    }
+  };
+
+  const readable = DynamodbStreamsReadable(
+    toCallbackStreamsClient(fakeV3Client),
+    'arn:aws:dynamodb:eu-west-1:000000000000:table/t/stream/2024',
+    {shardId: 'shard-1', readInterval: 1}
+  );
+
+  return new Promise((resolve, reject) => {
+    const seen = [];
+    readable
+      .on('data', recordSet => {
+        recordSet.forEach(r => seen.push(r));
+        if (seen.length > 0) readable.close();
+      })
+      .on('end', () => {
+        t.is(seen.length, 1);
+        t.is(seen[0].dynamodb.SequenceNumber, '111');
+        resolve();
+      })
+      .on('error', reject);
+  });
 });


### PR DESCRIPTION
…@aws-sdk v3

Closes #248. The plugin imported `aws-sdk/clients/dynamodb` and `aws-sdk/clients/dynamodbstreams` (v2) and pinned `aws-sdk@^2.1234.0`, which printed the AWS-SDK-v2 maintenance-mode warning.

Swap to the modular @aws-sdk v3 clients:
- `dynamodb-streams.js`: `DynamoDBClient`/`DynamoDBStreamsClient`, `waitFor('tableExists')` -> `waitUntilTableExists`, and `.promise()` -> `client.send(new DescribeTableCommand/DescribeStreamCommand(...))`.
- New `aws-client.js`: pure `toClientConfig` helper normalizing the flat v2-style options bag (region/endpoint/accessKeyId/secretAccessKey) into the v3 client config (credentials nested).
- New `dynamodb-streams-client.js`: thin callback shim adapting the v3 promise-based `send()` to the v2 callback contract (`getShardIterator`/`describeStream`/`getRecords`) that `dynamodb-streams-readable` consumes, so its pure helpers stay untouched.
- Update both package.json files (drop aws-sdk v2, add the v3 clients) and migrate the readable integration test off v2.

AVA unit tests cover toClientConfig, the callback shim, and an end-to-end DynamoDBStreamReadable read driven by a fake v3 `send()` client.