### PR TITLE
feat(serverless-offline-sqs): make receiveMessage long-poll wait conf…

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -149,6 +149,7 @@ custom:
     skipCacheInvalidation: false
     queueName: my-local-queue        # optional: override every sqs event's queue name locally
     enabled: true                    # optional: set false to skip the SQS emulator locally (#222)
+    waitTimeSeconds: 15              # optional: receiveMessage long-poll wait, clamped to 0-20 (#123)
 ```
 
 #### Disabling the plugin locally (#222)
@@ -163,3 +164,20 @@ enabled by default when the flag is absent.
 Setting `custom.serverless-offline-sqs.queueName` overrides the queue name resolved from each `sqs`
 event definition. This is handy when your local ElasticMQ queue is named differently from the one
 declared in your `serverless.yml` events, without having to edit the function event configuration.
+
+#### Long-poll wait (`waitTimeSeconds`, #123)
+
+Each queue is drained with a `ReceiveMessage` long-poll. By default the plugin waits **15 seconds**
+per poll (`WaitTimeSeconds`) before returning, which keeps poll churn — and the spurious `503`s that
+a 20s long-poll triggered against ElasticMQ/localstack (#123) — low while staying responsive.
+
+Set `custom.serverless-offline-sqs.waitTimeSeconds` (or pass `--waitTimeSeconds`) to tune it; the
+alias `pollingInterval` is also accepted. The value is clamped to the SQS long-poll range `0-20`
+(seconds); `0` performs an instant short-poll. A per-event `maximumBatchingWindow` still takes
+precedence over this plugin-level default for that queue.
+
+```yml
+custom:
+  serverless-offline-sqs:
+    waitTimeSeconds: 5   # poll every ~5s instead of the 15s default; 0 = short-poll
+```

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -16,6 +16,8 @@ const {
 const {normalizeLog} = require('./log');
 const SQS = require('./sqs');
 
+const {DEFAULT_WAIT_TIME_SECONDS} = SQS;
+
 const OFFLINE_OPTION = 'serverless-offline';
 const CUSTOM_OPTION = 'serverless-offline-sqs';
 
@@ -33,6 +35,14 @@ const defaultOptions = {
   // terminateIdleLambdaTime >= v13); default both to serverless-offline's own default (60s).
   functionCleanupIdleTimeSeconds: 60,
   terminateIdleLambdaTime: 60,
+
+  // #123 (zoellner): the receiveMessage long-poll wait used to be a hard-coded 5s fallback with no
+  // knob — the only lever was the per-event maximumBatchingWindow (#227). A 20s long-poll against
+  // ElasticMQ/localstack produced the frequent 503s in #123 (bisected to 40efaf9); esetnik agreed to
+  // expose it as config with the 20s default debated down to ~15s. Expose it as a plugin option
+  // (clamped to [0,20] in sqs.resolveDefaultWaitTimeSeconds); the event-level maximumBatchingWindow
+  // still wins per queue.
+  waitTimeSeconds: DEFAULT_WAIT_TIME_SECONDS,
 
   accountId: '000000000000'
 };

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -178,9 +178,29 @@ const toCreateQueueParams = (queueName, properties = {}) => {
 // maximumBatchingWindow property accepts 0-300.
 const SQS_MAX_WAIT_TIME_SECONDS = 20;
 
+// #123 (zoellner) / agreed by esetnik: the global long-poll fallback used to be a hard-coded 5s and
+// the only way to influence WaitTimeSeconds was the per-event maximumBatchingWindow (#227). A 20s
+// long-poll against ElasticMQ/localstack produced the frequent 503s in #123 (bisected to 40efaf9),
+// so the maintainer agreed to expose it as configuration with the 20s default debated down to ~15s.
+// 15s is the thread compromise: long enough to keep poll churn (and the 503s) low, short enough to
+// stay responsive.
+const DEFAULT_WAIT_TIME_SECONDS = 15;
+
+// #123 (zoellner): derive the plugin-level long-poll default from the merged options
+// (custom.serverless-offline-sqs.waitTimeSeconds, or `pollingInterval` as an alias). Clamp to the
+// SQS long-poll range [0, 20]; fall back to DEFAULT_WAIT_TIME_SECONDS when neither option is a finite
+// number (0 is honored, not falsy — it means short-poll). `waitTimeSeconds` wins over the alias.
+// Pure: reads only its argument, returns a number.
+const resolveDefaultWaitTimeSeconds = options => {
+  const configured = get('waitTimeSeconds', options);
+  const value = isFinite(configured) ? configured : get('pollingInterval', options);
+  return isFinite(value) ? clamp(0, SQS_MAX_WAIT_TIME_SECONDS, value) : DEFAULT_WAIT_TIME_SECONDS;
+};
+
 // #227 (tomusiaka): honor the event-level `maximumBatchingWindow` as the receiveMessage
-// WaitTimeSeconds instead of a hard-coded 5. Clamp to the SQS long-poll range [0, 20]; fall back to
-// the previous default when the option is absent or not a finite number (0 is honored, not falsy).
+// WaitTimeSeconds. Clamp to the SQS long-poll range [0, 20]; fall back to the supplied default
+// (#123: now the options-derived plugin default, no longer a hard-coded 5) when the option is absent
+// or not a finite number (0 is honored, not falsy).
 const resolveWaitTimeSeconds = (sqsEvent, defaultWaitTimeSeconds) =>
   isFinite(get('maximumBatchingWindow', sqsEvent))
     ? clamp(0, SQS_MAX_WAIT_TIME_SECONDS, sqsEvent.maximumBatchingWindow)
@@ -375,8 +395,14 @@ class SQS {
       (await this.client.getQueueUrl({QueueName: queueName}).promise()).QueueUrl
     );
 
-    // #227 (tomusiaka): use maximumBatchingWindow as the long-poll wait (default 5s) per queue.
-    const WaitTimeSeconds = resolveWaitTimeSeconds(sqsEvent, 5);
+    // #227 (tomusiaka): use the event-level maximumBatchingWindow as the long-poll wait per queue.
+    // #123 (zoellner): when no event window is set, fall back to the configurable plugin-level
+    // default (custom.serverless-offline-sqs.waitTimeSeconds / pollingInterval, default 15s) instead
+    // of the old hard-coded 5s that left the long-poll behavior untunable.
+    const WaitTimeSeconds = resolveWaitTimeSeconds(
+      sqsEvent,
+      resolveDefaultWaitTimeSeconds(this.options)
+    );
     // #221 (successkrisz): only honor partial-batch-failure when the mapping opts in.
     const reportBatchItemFailures = functionResponseType === 'ReportBatchItemFailures';
 
@@ -462,6 +488,8 @@ module.exports.normalizeQueueNames = normalizeQueueNames;
 module.exports.expandSqsEventDefinitions = expandSqsEventDefinitions;
 module.exports.toCreateQueueParams = toCreateQueueParams;
 module.exports.resolveWaitTimeSeconds = resolveWaitTimeSeconds;
+module.exports.resolveDefaultWaitTimeSeconds = resolveDefaultWaitTimeSeconds;
+module.exports.DEFAULT_WAIT_TIME_SECONDS = DEFAULT_WAIT_TIME_SECONDS;
 module.exports.partitionBatchForDeletion = partitionBatchForDeletion;
 module.exports.collectQueueDefinitions = collectQueueDefinitions;
 module.exports.extractDlqTargetName = extractDlqTargetName;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -8,6 +8,8 @@ const {
   resolveQueueName,
   toCreateQueueParams,
   resolveWaitTimeSeconds,
+  resolveDefaultWaitTimeSeconds,
+  DEFAULT_WAIT_TIME_SECONDS,
   partitionBatchForDeletion,
   collectQueueDefinitions,
   extractDlqTargetName,
@@ -17,6 +19,7 @@ const {
 } = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
+const ServerlessOfflineSQS = require('../src');
 const {defaultOptions, isPluginEnabled} = require('../src');
 const {extractQueueNameFromARN, resolveCfnValue} = require('../src/sqs-event-definition');
 
@@ -485,6 +488,113 @@ test('#227 resolveWaitTimeSeconds clamps to the SQS long-poll max of 20s', t => 
 
 test('#227 resolveWaitTimeSeconds clamps negatives to 0', t => {
   t.is(resolveWaitTimeSeconds({maximumBatchingWindow: -3}, 5), 0);
+});
+
+// ---------------------------------------------------------------------------
+// resolveDefaultWaitTimeSeconds — configurable long-poll wait (#123 zoellner)
+// The global long-poll fallback used to be a hard-coded 5s with no way to tune
+// the receiveMessage WaitTimeSeconds except per-event maximumBatchingWindow
+// (#227). A 20s long-poll against ElasticMQ/localstack produced frequent 503s
+// (#123, bisected by zoellner to 40efaf9); esetnik agreed to expose it as
+// configuration with the 20s default debated down to ~15s.
+// ---------------------------------------------------------------------------
+
+test('#123 DEFAULT_WAIT_TIME_SECONDS is the 15s thread compromise within the long-poll range', t => {
+  t.is(DEFAULT_WAIT_TIME_SECONDS, 15);
+  t.true(DEFAULT_WAIT_TIME_SECONDS >= 0 && DEFAULT_WAIT_TIME_SECONDS <= 20);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds falls back to the built-in default when unconfigured', t => {
+  t.is(resolveDefaultWaitTimeSeconds({}), DEFAULT_WAIT_TIME_SECONDS);
+  t.is(resolveDefaultWaitTimeSeconds(undefined), DEFAULT_WAIT_TIME_SECONDS);
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: undefined}), DEFAULT_WAIT_TIME_SECONDS);
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 'oops'}), DEFAULT_WAIT_TIME_SECONDS);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds honors a configured waitTimeSeconds', t => {
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 3}), 3);
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 20}), 20);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds honors 0 (instant short-poll), not treated as falsy', t => {
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 0}), 0);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds accepts pollingInterval as an alias', t => {
+  t.is(resolveDefaultWaitTimeSeconds({pollingInterval: 8}), 8);
+  // an explicit waitTimeSeconds wins over the pollingInterval alias
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 4, pollingInterval: 8}), 4);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds clamps to the SQS long-poll range [0, 20]', t => {
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: 300}), 20);
+  t.is(resolveDefaultWaitTimeSeconds({waitTimeSeconds: -3}), 0);
+});
+
+test('#123 a configured plugin default flows into resolveWaitTimeSeconds when no event window is set', t => {
+  // The plugin-level default is the fallback the live poll handler passes as the
+  // second arg of resolveWaitTimeSeconds; an event-level maximumBatchingWindow still wins.
+  const pluginDefault = resolveDefaultWaitTimeSeconds({waitTimeSeconds: 10});
+  t.is(resolveWaitTimeSeconds({}, pluginDefault), 10);
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 2}, pluginDefault), 2);
+});
+
+test('#123 the live poll handler passes the options-derived default to resolveWaitTimeSeconds', t => {
+  // source-level guard: the hard-coded `resolveWaitTimeSeconds(sqsEvent, 5)` must be gone,
+  // replaced by the options-derived plugin default.
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'sqs.js'), 'utf8');
+  t.false(/resolveWaitTimeSeconds\(sqsEvent,\s*5\)/.test(source));
+  t.true(
+    /resolveWaitTimeSeconds\(\s*sqsEvent,\s*resolveDefaultWaitTimeSeconds\(this\.options\)/.test(
+      source
+    )
+  );
+});
+
+test('#123 defaultOptions registers the waitTimeSeconds long-poll default (15s compromise)', t => {
+  t.is(defaultOptions.waitTimeSeconds, DEFAULT_WAIT_TIME_SECONDS);
+  t.is(defaultOptions.waitTimeSeconds, 15);
+});
+
+test('#123 resolveDefaultWaitTimeSeconds is a pure read with no side effects on its input', t => {
+  const options = {waitTimeSeconds: 7, region: 'eu-west-1'};
+  const before = {...options};
+  resolveDefaultWaitTimeSeconds(options);
+  t.deepEqual(options, before);
+});
+
+const mkPlugin = (custom, cliOptions = {}) =>
+  new ServerlessOfflineSQS({service: {custom, provider: {}}}, cliOptions, {log: normalizeLog()});
+
+test('#123 _mergeOptions threads a configured waitTimeSeconds through to the receiveMessage default', t => {
+  const plugin = mkPlugin({'serverless-offline-sqs': {waitTimeSeconds: 12}});
+  plugin._mergeOptions();
+  t.is(plugin.options.waitTimeSeconds, 12);
+  // and that merged value is exactly what the live poll handler uses as the WaitTimeSeconds fallback
+  t.is(resolveDefaultWaitTimeSeconds(plugin.options), 12);
+  t.is(resolveWaitTimeSeconds({}, resolveDefaultWaitTimeSeconds(plugin.options)), 12);
+});
+
+test('#123 _mergeOptions clamps an out-of-range configured waitTimeSeconds at the receiveMessage edge', t => {
+  const plugin = mkPlugin({'serverless-offline-sqs': {waitTimeSeconds: 300}});
+  plugin._mergeOptions();
+  // the raw option survives the merge as-is; clamping happens in resolveDefaultWaitTimeSeconds
+  t.is(plugin.options.waitTimeSeconds, 300);
+  t.is(resolveDefaultWaitTimeSeconds(plugin.options), 20);
+});
+
+test('#123 _mergeOptions falls back to the 15s default when waitTimeSeconds is unconfigured', t => {
+  const plugin = mkPlugin({'serverless-offline-sqs': {autoCreate: true}});
+  plugin._mergeOptions();
+  t.is(plugin.options.waitTimeSeconds, DEFAULT_WAIT_TIME_SECONDS);
+  t.is(resolveDefaultWaitTimeSeconds(plugin.options), 15);
+});
+
+test('#123 a --waitTimeSeconds CLI option overrides custom config through the merge pipeline', t => {
+  const plugin = mkPlugin({'serverless-offline-sqs': {waitTimeSeconds: 12}}, {waitTimeSeconds: 3});
+  plugin._mergeOptions();
+  t.is(plugin.options.waitTimeSeconds, 3);
+  t.is(resolveDefaultWaitTimeSeconds(plugin.options), 3);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
…igurable (#123)

The global long-poll fallback was a hard-coded 5s and the only way to influence the ReceiveMessage WaitTimeSeconds was the per-event maximumBatchingWindow (#227). A 20s long-poll against ElasticMQ/localstack produced the frequent 503s in #123 (bisected by zoellner to 40efaf9); esetnik agreed in-thread to expose it as configuration with the 20s default debated down to ~15s.

Add a `waitTimeSeconds` plugin option (custom.serverless-offline-sqs, with `pollingInterval` as an alias) threaded through `_sqsEvent` as the default passed to the existing resolveWaitTimeSeconds — the event-level maximumBatchingWindow still wins per queue. The new pure helper resolveDefaultWaitTimeSeconds clamps to the SQS long-poll range [0, 20] and falls back to the 15s thread compromise. The option is registered in defaultOptions and merged via the existing _mergeOptions pipeline. Documented in the package README.

Closes #123