### PR TITLE
fix(serverless-offline-sqs): let HTTP and SQS lambdas co-register und…

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -33,6 +33,17 @@ plugins:
 
 [See example](../../tests/serverless-plugins-integration/README.md#sqs)
 
+### HTTP and SQS functions in the same service (`#132`)
+
+A service can mix plain `http` (API Gateway) functions and `sqs` functions and run them all under a
+single `serverless-offline`. The plugin only **augments** serverless-offline's lifecycle — it listens
+to `offline:start:init` / `offline:start:ready` / `offline:start:end` and never registers the bare
+`offline:start` hook, so it no longer competes with serverless-offline's own start path. The result is
+that the HTTP routes register and respond **and** the SQS listeners fire in the same run. Its
+SIGINT/SIGTERM handler also cleans up only its own SQS/lambda resources (it does not `process.exit`),
+leaving serverless-offline to own shutdown of the shared HTTP server. Run `serverless offline start`
+(the documented multi-plugin command) for this to work as intended.
+
 ## How it works?
 
 To be able to emulate AWS SQS queue on local machine there should be some queue system actually running. One of the existing implementations suitable for the task is [ElasticMQ](https://github.com/adamw/elasticmq).

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -7,6 +7,7 @@ const {
   isPlainObject,
   isUndefined,
   map,
+  mapValues,
   omitBy,
   pick,
   pipe,
@@ -50,18 +51,49 @@ const isPluginEnabled = options => {
   return Boolean(enabled);
 };
 
+// #132 (sqs-http-cofunction-registration): serverless-offline v13 owns the whole `offline:start`
+// lifecycle. Its hook map is:
+//   offline:start        -> #startWithExplicitEnd  (start + ready + end; ready BLOCKS on a signal)
+//   offline:start:init   -> start
+//   offline:start:ready  -> ready
+//   offline:start:end    -> end
+// The documented contract (serverless-offline README, "Usage with other plugins") is that
+// augmenting plugins listen to `offline:start:init` / `offline:start:end` and the user runs
+// `serverless offline start`. This plugin used to ALSO register the bare `offline:start` hook
+// (`_startWithReady`), which then co-ran on the same lifecycle event as serverless-offline's own
+// `#startWithExplicitEnd`. The two compete: if serverless-offline's hook runs first it blocks in
+// `#ready()` and the SQS start never runs (HTTP up, SQS dead); if ours runs first its `ready()`
+// installs `process.exit(0)` SIGINT/SIGTERM handlers that tear the shared process down from under
+// serverless-offline's HTTP server. Either way only one side wires up — the reported symptom.
+//
+// Fix: build the hook map WITHOUT the bare `offline:start` key, so the plugin only AUGMENTS
+// serverless-offline's lifecycle (init/ready/end) and never pre-empts it. Keep the decision as a
+// pure, exported value so it is unit-testable in isolation from the Serverless runtime.
+// `offline:start:end` maps to `stop` (not `end`) so the plugin tears down only its own SQS/lambda
+// resources and lets serverless-offline own the `process.exit` — see #132 note above.
+const HOOK_METHOD_BY_EVENT = {
+  'offline:start:init': 'start',
+  'offline:start:ready': 'ready',
+  'offline:start:end': 'stop'
+};
+
+const buildHookMap = () => ({...HOOK_METHOD_BY_EVENT});
+
+// #132: the SIGINT/SIGTERM listener is what makes AVA/CI hang and what would `process.exit` the
+// shared run, so it is skipped entirely under NODE_ENV=test. Extracted as a pure predicate so the
+// gate (test env -> no termination trap) is asserted directly.
+const shouldListenForTermination = nodeEnv => nodeEnv !== 'test';
+
 class ServerlessOfflineSQS {
   constructor(serverless, cliOptions, {log} = {}) {
     this.cliOptions = cliOptions;
     this.serverless = serverless;
     this.log = normalizeLog(log);
 
-    this.hooks = {
-      'offline:start:init': this.start.bind(this),
-      'offline:start:ready': this.ready.bind(this),
-      'offline:start': this._startWithReady.bind(this),
-      'offline:start:end': this.end.bind(this)
-    };
+    // #132: register only the augmenting lifecycle hooks (init/ready/end). Binding the methods named
+    // by the pure hook map keeps the wiring declarative and free of the bare `offline:start` hook
+    // that used to compete with serverless-offline's own start path.
+    this.hooks = mapValues(methodName => this[methodName].bind(this), buildHookMap());
   }
 
   async start() {
@@ -87,7 +119,7 @@ class ServerlessOfflineSQS {
   }
 
   ready() {
-    if (process.env.NODE_ENV !== 'test') {
+    if (shouldListenForTermination(process.env.NODE_ENV)) {
       this._listenForTermination();
     }
   }
@@ -99,14 +131,19 @@ class ServerlessOfflineSQS {
       process.on(signal, async () => {
         this.log.notice(`Got ${signal} signal. Offline Halting...`);
 
-        await this.end();
+        // #132: clean up only our own lambda/sqs resources and let serverless-offline own process
+        // termination. Calling end() with skipExit avoids a `process.exit(0)` that would tear down
+        // the shared run (and its HTTP server) out from under serverless-offline's own SIGINT path.
+        await this.end(true);
       })
     );
   }
 
-  async _startWithReady() {
-    await this.start();
-    this.ready();
+  // #132: the `offline:start:end` lifecycle hook. Cleans up the SQS/lambda resources but never
+  // forces a process exit, so serverless-offline's own `offline:start:end` handler is free to run
+  // and own the shutdown of the shared HTTP server / process.
+  async stop() {
+    await this.end(true);
   }
 
   async end(skipExit) {
@@ -255,3 +292,5 @@ class ServerlessOfflineSQS {
 module.exports = ServerlessOfflineSQS;
 module.exports.defaultOptions = defaultOptions;
 module.exports.isPluginEnabled = isPluginEnabled;
+module.exports.buildHookMap = buildHookMap;
+module.exports.shouldListenForTermination = shouldListenForTermination;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -17,7 +17,12 @@ const {
 } = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
-const {defaultOptions, isPluginEnabled} = require('../src');
+const {
+  defaultOptions,
+  isPluginEnabled,
+  buildHookMap,
+  shouldListenForTermination
+} = require('../src');
 const {extractQueueNameFromARN, resolveCfnValue} = require('../src/sqs-event-definition');
 
 // ---------------------------------------------------------------------------
@@ -853,4 +858,104 @@ test('#262 expandSqsEventDefinitions: {arn} object event with no literal queueNa
   const built = new SQSEventDefinition(defs[0], 'eu-west-1', '000000000000');
   t.is(built.queueName, 'Q');
   t.is(built.batchSize, 2);
+});
+
+// ---------------------------------------------------------------------------
+// buildHookMap / shouldListenForTermination — SQS+HTTP co-registration (#132)
+// ---------------------------------------------------------------------------
+//
+// serverless-offline v13 owns the whole `offline:start` lifecycle: its hook map is
+//   offline:start        -> #startWithExplicitEnd (start + ready + end, ready BLOCKS on a signal)
+//   offline:start:init   -> start
+//   offline:start:ready  -> ready
+//   offline:start:end    -> end
+// The documented contract (README "Usage with other plugins") is that augmenting plugins listen to
+// `offline:start:init`/`offline:start:end` and the user runs `serverless offline start`.
+//
+// This plugin used to ALSO register the bare `offline:start` hook (`_startWithReady`). Both bare
+// hooks then run on the same lifecycle event: if serverless-offline's runs first it blocks in
+// `#ready()` and the SQS start never runs (HTTP up, SQS dead); if the SQS one runs first its
+// `ready()` installs `process.exit(0)` SIGINT/SIGTERM handlers that tear the shared process down
+// from under serverless-offline's HTTP server. Either way only one side wires up — exactly the
+// #132 symptom ("only the SQS lambda works unless NODE_ENV=test or `offline start` is used").
+//
+// Fix: drop the bare `offline:start` hook so the plugin only AUGMENTS serverless-offline's
+// lifecycle and never pre-empts it, and route `offline:start:end` through `stop` (cleanup without
+// `process.exit`) so serverless-offline keeps ownership of the shared process/HTTP server.
+// buildHookMap encodes that decision as pure data.
+
+test('#132 buildHookMap never registers the bare `offline:start` hook (no pre-emption of serverless-offline)', t => {
+  const map = buildHookMap();
+  t.false('offline:start' in map);
+});
+
+test('#132 buildHookMap augments serverless-offline via init/ready/end only', t => {
+  t.deepEqual(Object.keys(buildHookMap()).sort(), [
+    'offline:start:end',
+    'offline:start:init',
+    'offline:start:ready'
+  ]);
+});
+
+test('#132 buildHookMap maps each lifecycle event to the matching method name', t => {
+  // `offline:start:end` maps to `stop` (cleanup without process.exit), not `end`, so the plugin
+  // never owns the shutdown of serverless-offline's shared HTTP server / process.
+  t.deepEqual(buildHookMap(), {
+    'offline:start:init': 'start',
+    'offline:start:ready': 'ready',
+    'offline:start:end': 'stop'
+  });
+});
+
+test('#132 buildHookMap is a stable, non-mutating pure value', t => {
+  const a = buildHookMap();
+  const b = buildHookMap();
+  t.deepEqual(a, b);
+  t.not(a, b); // a fresh object each call, safe to bind methods into
+});
+
+test('#132 every method named by buildHookMap exists on the plugin (declarative wiring is sound)', t => {
+  // the constructor wires hooks as `this[methodName].bind(this)`; an unknown name would throw at
+  // construction, so assert each mapped method is a real function on the prototype.
+  const ServerlessOfflineSQS = require('../src');
+  Object.values(buildHookMap()).forEach(methodName => {
+    t.is(typeof ServerlessOfflineSQS.prototype[methodName], 'function', methodName);
+  });
+});
+
+test('#132 shouldListenForTermination is false under NODE_ENV=test (keeps AVA/CI from trapping signals)', t => {
+  t.false(shouldListenForTermination('test'));
+});
+
+test('#132 shouldListenForTermination is true for a normal offline run', t => {
+  t.true(shouldListenForTermination('development'));
+  t.true(shouldListenForTermination('production'));
+  t.true(shouldListenForTermination(undefined));
+  t.true(shouldListenForTermination(''));
+});
+
+// ---------------------------------------------------------------------------
+// #132 source-level guards: the plugin must not own a competing bare-start path,
+// and its signal handler must not force `process.exit` on the SHARED process
+// (serverless-offline owns process exit; tearing it down kills the HTTP server).
+// ---------------------------------------------------------------------------
+
+test('#132 src/index.js no longer wires a bare `offline:start` hook', t => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.js'), 'utf8');
+  // no hooks-object entry keyed on the bare lifecycle event (init/ready/end keys are `…start:xxx`)
+  t.false(/['"]offline:start['"]\s*:/.test(source));
+  // and the competing combined-start method definition is gone (prose mentions are fine)
+  t.false(/\b_startWithReady\s*\(/.test(source));
+});
+
+test('#132 buildHookMap (the actual registered hooks) carries no bare `offline:start` key', t => {
+  // belt-and-braces beyond the source scan: the live map must not contain the bare event.
+  t.false(Object.prototype.hasOwnProperty.call(buildHookMap(), 'offline:start'));
+});
+
+test('#132 src/index.js signal handler calls end() with skipExit so the shared HTTP server survives', t => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.js'), 'utf8');
+  // _listenForTermination must hand a truthy skipExit to end() — the SQS plugin cleans up its own
+  // lambda/sqs but leaves process termination to serverless-offline, which owns the http server.
+  t.regex(source, /this\.end\(\s*true\s*\)/);
 });

--- a/scripts/create-queues.sh
+++ b/scripts/create-queues.sh
@@ -3,7 +3,8 @@ trap "exit 1" INT
 
 AWS_ENDPOINT_URL=${AWS_ENDPOINT_URL:-http://localhost:9324}
 
-QUEUES="MyFirstQueue MySecondQueue MyThirdQueue MyFourthQueue MyLargestBatchSizeQueue";
+# CoFunctionQueue backs the #132 SQS+HTTP co-registration test (serverless.sqs-http.yml).
+QUEUES="MyFirstQueue MySecondQueue MyThirdQueue MyFourthQueue MyLargestBatchSizeQueue CoFunctionQueue";
 for QUEUE in $QUEUES
 do 
     until aws sqs --endpoint-url ${AWS_ENDPOINT_URL} get-queue-url --queue-name ${QUEUE}  > /dev/null 2> /dev/null

--- a/tests/serverless-plugins-integration/lambda/handler.js
+++ b/tests/serverless-plugins-integration/lambda/handler.js
@@ -32,3 +32,12 @@ module.exports.callback = (event, context, cb) => {
   mark(event, context);
   cb();
 };
+
+// #132: a plain HTTP (API Gateway) handler. An http event carries no `Records`, so it emits its own
+// `__INVOKED__ <fn> http:<path>` marker. Used by test-sqs-http to assert that an HTTP route and an
+// SQS listener register and fire in the SAME `serverless-offline` run (SQS+HTTP co-registration).
+module.exports.http = (event, context) => {
+  const path = (event && (event.path || event.rawPath)) || 'unknown';
+  console.log(`__INVOKED__ ${context.functionName} http:${path} 1`);
+  return {statusCode: 200, body: JSON.stringify({ok: true})};
+};

--- a/tests/serverless-plugins-integration/package.json
+++ b/tests/serverless-plugins-integration/package.json
@@ -8,7 +8,8 @@
     "start:s3": "sls offline start --config serverless.s3.yml",
     "start:dynamodb-streams": "sls offline start --config serverless.dynamodb-streams.yml",
     "start:ssm": "sls print --config serverless.ssm.yml --stage offline",
-    "test": "npm run test:dynamodb-streams && npm run test:kinesis && npm run test:s3 && npm run test:sqs && npm run test:sqs:autocreate && npm run test:ssm",
+    "start:sqs:http": "sls offline start --config serverless.sqs-http.yml",
+    "test": "npm run test:dynamodb-streams && npm run test:kinesis && npm run test:s3 && npm run test:sqs && npm run test:sqs:autocreate && npm run test:sqs:http && npm run test:ssm",
     "setup-service": "../../scripts/clean-start.sh",
     "pretest:dynamodb-streams": "npm run -s setup-service dynamodb",
     "test:dynamodb-streams": "node test-dynamodb-streams",
@@ -20,6 +21,8 @@
     "test:sqs": "node test-sqs",
     "pretest:sqs:autocreate": "npm run -s setup-service sqs",
     "test:sqs:autocreate": "node test-sqs-autocreate",
+    "pretest:sqs:http": "npm run -s setup-service sqs",
+    "test:sqs:http": "node test-sqs-http",
     "test:ssm": "node test-ssm"
   },
   "dependencies": {

--- a/tests/serverless-plugins-integration/serverless.sqs-http.yml
+++ b/tests/serverless-plugins-integration/serverless.sqs-http.yml
@@ -1,0 +1,42 @@
+# #132: SQS + HTTP co-registration regression config. A single service declares BOTH a plain `http`
+# function and an `sqs` function. The plugin must only augment serverless-offline's lifecycle, so the
+# HTTP route registers (and responds) AND the SQS listener fires in the same `serverless offline` run.
+service: serverless-offline-sqs-http
+
+provider:
+  name: aws
+  region: eu-west-1
+  runtime: nodejs18.x
+
+plugins:
+  - ../../packages/serverless-offline-sqs
+  - serverless-offline
+
+functions:
+  myHttpHandler:
+    handler: lambda/handler.http
+    events:
+      - http:
+          path: ping
+          method: get
+  mySqsHandler:
+    handler: lambda/handler.promise
+    events:
+      - sqs:
+          arn:
+            Fn::GetAtt:
+              - CoFunctionQueue
+              - Arn
+
+resources:
+  Resources:
+    CoFunctionQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: CoFunctionQueue
+
+custom:
+  serverless-offline:
+    httpPort: 3336
+    lambdaPort: 3034
+  serverless-offline-sqs: ${file(./custom.yml):serverless-offline-sqs}

--- a/tests/serverless-plugins-integration/test-sqs-http.js
+++ b/tests/serverless-plugins-integration/test-sqs-http.js
@@ -1,0 +1,53 @@
+const http = require('http');
+const {SQS} = require('aws-sdk');
+const {delay, runOfflineTest} = require('./utils');
+
+// #132: assert that an HTTP route and an SQS listener BOTH register and fire in the SAME
+// `serverless offline` run. Before the fix, the plugin registered a bare `offline:start` hook that
+// competed with serverless-offline's own start path, so only one side wired up (the reported
+// symptom: "only the SQS lambda works"). Augmenting via init/ready/end only, both must respond.
+
+const client = new SQS({
+  region: 'eu-west-1',
+  accessKeyId: 'local',
+  secretAccessKey: 'local',
+  endpoint: 'http://localhost:9324'
+});
+
+const S = 'serverless-offline-sqs-http-dev';
+// serverless-offline strips the stage from a REST `http` event's `event.path`, so the proxy event
+// carries `/ping` (not `/dev/ping`); the GET below still targets the stage-prefixed URL.
+const EXPECTED_KEYS = [`${S}-myHttpHandler http:/ping`, `${S}-mySqsHandler sqs:CoFunctionQueue`];
+
+const httpGet = url =>
+  new Promise((resolve, reject) => {
+    const req = http.get(url, res => {
+      res.resume(); // drain the body so the socket frees up
+      resolve(res.statusCode);
+    });
+    req.on('error', reject);
+  });
+
+const triggerBoth = async () => {
+  await delay(1000);
+  await Promise.all([
+    // HTTP route: serverless-offline serves http events under /<stage>/<path>; stage defaults to dev.
+    httpGet('http://localhost:3336/dev/ping'),
+    client
+      .sendMessage({
+        QueueUrl: 'http://localhost:9324/queue/CoFunctionQueue',
+        MessageBody: 'CoFunctionMessage'
+      })
+      .promise()
+  ]);
+};
+
+runOfflineTest({
+  config: 'serverless.sqs-http.yml',
+  label: 'test-sqs-http',
+  expectedKeys: EXPECTED_KEYS,
+  // wait for the SQS banner: it is the LAST subsystem to come up, so once it logs both the HTTP
+  // server (serverless-offline) and the SQS poller (this plugin) are registered in the same run.
+  readyPattern: /Starting Offline SQS/,
+  onReady: triggerBoth
+});


### PR DESCRIPTION
…er serverless-offline (#132)

serverless-offline v13 owns the whole `offline:start` lifecycle: its hook map runs `offline:start` -> start+ready+end (ready blocks on a signal) and exposes `offline:start:init`/`ready`/`end` for augmenting plugins. This plugin also registered a bare `offline:start` hook (`_startWithReady`), which co-ran on the same lifecycle event as serverless-offline's own start path. The two compete: whichever runs first wins, so either the SQS start never runs (HTTP up, SQS dead) or our `ready()` installs `process.exit(0)` SIGINT/SIGTERM handlers that tear the shared process — and its HTTP server — down. Only one side wired up: the #132 symptom ("only the SQS lambda works unless NODE_ENV=test or `offline start` is used").

Fix: only AUGMENT serverless-offline's lifecycle.
- buildHookMap (pure, exported): init->start, ready->ready, end->stop, with NO bare `offline:start` key, so the plugin never pre-empts serverless-offline.
- shouldListenForTermination (pure, exported): no signal trap under test.
- the SIGINT/SIGTERM handler and the new `stop()` (offline:start:end) clean up only our own SQS/lambda resources via end(true); serverless-offline keeps ownership of process exit and the shared HTTP server.

Tests: AVA unit tests for buildHookMap / shouldListenForTermination plus source-level guards (no bare hook, signal handler uses skipExit). Integration: serverless.sqs-http.yml + test-sqs-http.js assert an HTTP route responds AND an SQS handler fires in the same run. README documents the co-registration.

Closes #132