### PR TITLE
feat(serverless-offline-sqs): make receiveMessage long-poll waitTimeSeconds configurable (#123)

### DIFF
--- a/packages/serverless-offline-sqs/README.md
+++ b/packages/serverless-offline-sqs/README.md
@@ -149,6 +149,7 @@ custom:
     skipCacheInvalidation: false
     queueName: my-local-queue        # optional: override every sqs event's queue name locally
     enabled: true                    # optional: set false to skip the SQS emulator locally (#222)
+    waitTimeSeconds: 5               # optional: default ReceiveMessage long-poll wait, 0-20s (#123)
 ```
 
 #### Disabling the plugin locally (#222)
@@ -163,3 +164,18 @@ enabled by default when the flag is absent.
 Setting `custom.serverless-offline-sqs.queueName` overrides the queue name resolved from each `sqs`
 event definition. This is handy when your local ElasticMQ queue is named differently from the one
 declared in your `serverless.yml` events, without having to edit the function event configuration.
+
+#### `waitTimeSeconds` long-poll default (#123)
+
+By default the plugin polls each queue with a `ReceiveMessage` `WaitTimeSeconds` of **5s** (SQS long
+polling). Set `custom.serverless-offline-sqs.waitTimeSeconds` (or pass `--waitTimeSeconds <n>`) to
+change that default — e.g. `0` for an instant short-poll, or up to `20` for the maximum long poll.
+The value is coerced from a string (YAML/CLI may deliver it as text) and clamped to the SQS-supported
+range `[0, 20]`. A function event that sets its own `maximumBatchingWindow` still wins over this
+default for that queue.
+
+```yml
+custom:
+  serverless-offline-sqs:
+    waitTimeSeconds: 0   # instant short-poll locally; or up to 20 for full long polling
+```

--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -26,6 +26,13 @@ const defaultOptions = {
   startingPosition: 'TRIM_HORIZON',
   autoCreate: false,
 
+  // #123: default receiveMessage long-poll WaitTimeSeconds. Overridable per service via
+  // custom.serverless-offline-sqs.waitTimeSeconds or the --waitTimeSeconds CLI flag (both threaded
+  // through _mergeOptions over this default); a per-event `maximumBatchingWindow` still wins. Kept at
+  // the historical 5s — do NOT raise it (a higher default slows local short-poll dev loops). Coerced
+  // and clamped to [0, 20] at use in resolveWaitTimeSeconds, so a string from YAML/CLI is honored.
+  waitTimeSeconds: 5,
+
   // #158 (raymond-w-ko): serverless-offline's LambdaFunctionPool schedules its idle-cleanup timer
   // as setTimeout(fn, options.<idleOption> * 1000). The plugin builds its own pool options, so when
   // the option is missing the product is NaN and the timer busy-loops at ~50% CPU on idle. The key

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -178,13 +178,31 @@ const toCreateQueueParams = (queueName, properties = {}) => {
 // maximumBatchingWindow property accepts 0-300.
 const SQS_MAX_WAIT_TIME_SECONDS = 20;
 
-// #227 (tomusiaka): honor the event-level `maximumBatchingWindow` as the receiveMessage
-// WaitTimeSeconds instead of a hard-coded 5. Clamp to the SQS long-poll range [0, 20]; fall back to
-// the previous default when the option is absent or not a finite number (0 is honored, not falsy).
+// #227: the historical hard-coded receiveMessage long-poll wait, also the fallback when a configured
+// value is missing or unusable.
+const DEFAULT_WAIT_TIME_SECONDS = 5;
+
+// #123: the configurable long-poll default (custom.serverless-offline-sqs.waitTimeSeconds or the
+// --waitTimeSeconds CLI flag) may arrive as a number OR — via YAML/CLI — as a string, exactly like
+// the `enabled` flag (#222). Coerce a bare string with Number() (mirroring isPluginEnabled rather
+// than silently ignoring it), reject NaN/nil by falling back to `fallback`, then clamp to the SQS
+// long-poll range [0, 20]. Pure + total: never returns NaN. 0 is honored (instant short-poll).
+const coerceWaitTimeSeconds = (value, fallback = DEFAULT_WAIT_TIME_SECONDS) => {
+  // An empty/whitespace-only string is "unset", not a deliberate 0 (Number('') === 0), so fall back.
+  if (isString(value) && trim(value) === '') return fallback;
+  const coerced = isString(value) ? Number(value) : value;
+  if (!isFinite(coerced)) return fallback;
+  return clamp(0, SQS_MAX_WAIT_TIME_SECONDS, coerced);
+};
+
+// #227 (tomusiaka) + #123: resolve the receiveMessage WaitTimeSeconds for one queue. The event-level
+// `maximumBatchingWindow` still WINS when present (clamped to [0, 20]); otherwise fall back to the
+// configured options default (`defaultWaitTimeSeconds`, itself coerced/clamped — string-safe). 0 is
+// honored (not treated as falsy); a non-finite per-event window defers to the default.
 const resolveWaitTimeSeconds = (sqsEvent, defaultWaitTimeSeconds) =>
   isFinite(get('maximumBatchingWindow', sqsEvent))
     ? clamp(0, SQS_MAX_WAIT_TIME_SECONDS, sqsEvent.maximumBatchingWindow)
-    : defaultWaitTimeSeconds;
+    : coerceWaitTimeSeconds(defaultWaitTimeSeconds);
 
 // #221 (successkrisz): support SQS partial batch failure reporting. When the event mapping sets
 // `functionResponseType: ReportBatchItemFailures`, the handler returns
@@ -375,8 +393,10 @@ class SQS {
       (await this.client.getQueueUrl({QueueName: queueName}).promise()).QueueUrl
     );
 
-    // #227 (tomusiaka): use maximumBatchingWindow as the long-poll wait (default 5s) per queue.
-    const WaitTimeSeconds = resolveWaitTimeSeconds(sqsEvent, 5);
+    // #227 (tomusiaka) + #123: use the event-level maximumBatchingWindow as the long-poll wait when
+    // present; otherwise the configurable default (custom.serverless-offline-sqs.waitTimeSeconds /
+    // --waitTimeSeconds, default 5s). resolveWaitTimeSeconds coerces a string option and clamps both.
+    const WaitTimeSeconds = resolveWaitTimeSeconds(sqsEvent, this.options.waitTimeSeconds);
     // #221 (successkrisz): only honor partial-batch-failure when the mapping opts in.
     const reportBatchItemFailures = functionResponseType === 'ReportBatchItemFailures';
 
@@ -462,6 +482,7 @@ module.exports.normalizeQueueNames = normalizeQueueNames;
 module.exports.expandSqsEventDefinitions = expandSqsEventDefinitions;
 module.exports.toCreateQueueParams = toCreateQueueParams;
 module.exports.resolveWaitTimeSeconds = resolveWaitTimeSeconds;
+module.exports.coerceWaitTimeSeconds = coerceWaitTimeSeconds;
 module.exports.partitionBatchForDeletion = partitionBatchForDeletion;
 module.exports.collectQueueDefinitions = collectQueueDefinitions;
 module.exports.extractDlqTargetName = extractDlqTargetName;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -3,11 +3,13 @@ const path = require('path');
 const test = require('ava');
 
 const {defaultLog, normalizeLog} = require('../src/log');
+const SQS = require('../src/sqs');
 const {
   toDeleteEntries,
   resolveQueueName,
   toCreateQueueParams,
   resolveWaitTimeSeconds,
+  coerceWaitTimeSeconds,
   partitionBatchForDeletion,
   collectQueueDefinitions,
   extractDlqTargetName,
@@ -485,6 +487,119 @@ test('#227 resolveWaitTimeSeconds clamps to the SQS long-poll max of 20s', t => 
 
 test('#227 resolveWaitTimeSeconds clamps negatives to 0', t => {
   t.is(resolveWaitTimeSeconds({maximumBatchingWindow: -3}, 5), 0);
+});
+
+// ---------------------------------------------------------------------------
+// coerceWaitTimeSeconds + configurable options default (#123 sqs-waittime-config)
+// ---------------------------------------------------------------------------
+
+test('#123 coerceWaitTimeSeconds passes a numeric value through', t => {
+  t.is(coerceWaitTimeSeconds(10), 10);
+  t.is(coerceWaitTimeSeconds(0), 0);
+});
+
+test('#123 coerceWaitTimeSeconds coerces a numeric string via Number()', t => {
+  // YAML/CLI may deliver the value as a string; mirror isPluginEnabled's string handling — do NOT
+  // silently ignore a bare string.
+  t.is(coerceWaitTimeSeconds('10'), 10);
+  t.is(coerceWaitTimeSeconds('0'), 0);
+});
+
+test('#123 coerceWaitTimeSeconds clamps to the SQS long-poll range [0, 20]', t => {
+  t.is(coerceWaitTimeSeconds(300), 20);
+  t.is(coerceWaitTimeSeconds('300'), 20);
+  t.is(coerceWaitTimeSeconds(-3), 0);
+  t.is(coerceWaitTimeSeconds('-3'), 0);
+});
+
+test('#123 coerceWaitTimeSeconds falls back to 5 for non-numeric / nil input', t => {
+  // a non-numeric string is NaN under Number() and must NOT be honored: fall back to the default 5.
+  t.is(coerceWaitTimeSeconds('oops'), 5);
+  t.is(coerceWaitTimeSeconds(undefined), 5);
+  t.is(coerceWaitTimeSeconds(null), 5);
+  t.is(coerceWaitTimeSeconds(''), 5);
+});
+
+test('#123 coerceWaitTimeSeconds honors an explicit override fallback', t => {
+  t.is(coerceWaitTimeSeconds('oops', 7), 7);
+  t.is(coerceWaitTimeSeconds(undefined, 7), 7);
+});
+
+test('#123 resolveWaitTimeSeconds uses the options default (numeric or string) when no per-event window', t => {
+  t.is(resolveWaitTimeSeconds({}, 15), 15);
+  t.is(resolveWaitTimeSeconds({}, '15'), 15);
+  // clamps the options default too
+  t.is(resolveWaitTimeSeconds({}, 300), 20);
+  t.is(resolveWaitTimeSeconds({}, '300'), 20);
+  // bad options default falls back to 5, never NaN
+  t.is(resolveWaitTimeSeconds({}, 'oops'), 5);
+});
+
+test('#123 resolveWaitTimeSeconds: per-event maximumBatchingWindow still wins over the options default', t => {
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 8}, 15), 8);
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 8}, '15'), 8);
+  // and is itself clamped
+  t.is(resolveWaitTimeSeconds({maximumBatchingWindow: 300}, '15'), 20);
+});
+
+test('#123 defaultOptions.waitTimeSeconds defaults to 5 (NOT raised)', t => {
+  t.is(defaultOptions.waitTimeSeconds, 5);
+});
+
+// ---------------------------------------------------------------------------
+// #123 merge test: the configured waitTimeSeconds reaches the receiveMessage params.
+// Instantiate the real SQS class with a mocked client + lambda and capture the long-poll
+// WaitTimeSeconds passed to receiveMessage.
+// ---------------------------------------------------------------------------
+
+const captureReceiveMessage = async (options, rawDefinition) => {
+  const captured = [];
+  const sqs = new SQS(null, {}, {...options, region: 'eu-west-1', accountId: '0'}, undefined);
+
+  // replace the real AWS client with a capturing mock; pause the poll queue after the first poll so
+  // the recursive job does not loop forever.
+  sqs.client = {
+    getQueueUrl: () => ({promise: () => Promise.resolve({QueueUrl: 'http://local/q'})}),
+    receiveMessage: params => {
+      captured.push(params);
+      sqs.queue.pause();
+      return {promise: () => Promise.resolve({Messages: []})};
+    }
+  };
+
+  const sqsEvent = new SQSEventDefinition(rawDefinition || {queueName: 'q'}, 'eu-west-1', '0');
+  await sqs._sqsEvent('fn', sqsEvent);
+  sqs.queue.start();
+  // let the queued job drain
+  await new Promise(resolve => {
+    setTimeout(resolve, 50);
+  });
+
+  return captured;
+};
+
+test('#123 configured waitTimeSeconds reaches the receiveMessage WaitTimeSeconds param', async t => {
+  const captured = await captureReceiveMessage({waitTimeSeconds: 15});
+  t.true(captured.length > 0);
+  t.is(captured[0].WaitTimeSeconds, 15);
+});
+
+test('#123 a string waitTimeSeconds option is coerced before reaching receiveMessage', async t => {
+  const captured = await captureReceiveMessage({waitTimeSeconds: '12'});
+  t.is(captured[0].WaitTimeSeconds, 12);
+});
+
+test('#123 receiveMessage WaitTimeSeconds defaults to 5 when no option is set', async t => {
+  const captured = await captureReceiveMessage({});
+  t.is(captured[0].WaitTimeSeconds, 5);
+});
+
+test('#123 per-event maximumBatchingWindow overrides the configured waitTimeSeconds at the receiveMessage call', async t => {
+  const captured = await captureReceiveMessage(
+    {waitTimeSeconds: 15},
+    {queueName: 'q', maximumBatchingWindow: 8}
+  );
+  t.is(captured[0].WaitTimeSeconds, 8);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Make the `serverless-offline-sqs` `ReceiveMessage` long-poll wait (`WaitTimeSeconds`) configurable via a new `waitTimeSeconds` plugin option (`custom.serverless-offline-sqs.waitTimeSeconds`, or the `--waitTimeSeconds <n>` CLI flag), instead of the previously hard-coded global value. The option is threaded through `_mergeOptions` into `_sqsEvent`, coerced from a string and clamped to the SQS long-poll range `[0, 20]`, and defaults to **5s**. A per-event `maximumBatchingWindow` still wins per queue.

## Why

`#123`: `serverless-offline-sqs` was producing frequent `503: Service Unavailable` responses against ElasticMQ/localstack. @zoellner bisected the regression to 40efaf9 (by @esetnik), which raised the long-poll wait toward the SQS maximum; lower values work fine. There was no supported way to tune the wait short of editing per-event `maximumBatchingWindow` (#227). This exposes the wait as first-class configuration, keeping the safe historical default of 5s rather than the problematic high value.

## Acceptance criteria (EARS)

- [x] **The plugin shall default the `ReceiveMessage` `WaitTimeSeconds` to 5 seconds when `waitTimeSeconds` is not configured.**
      Evidence: `defaultOptions.waitTimeSeconds === 5` (`src/index.js`); tests `#123 defaultOptions.waitTimeSeconds defaults to 5 (NOT raised)` and `#123 receiveMessage WaitTimeSeconds defaults to 5 when no option is set` pass.
- [x] **When `custom.serverless-offline-sqs.waitTimeSeconds` (or `--waitTimeSeconds`) is set, the plugin shall use that value as the `ReceiveMessage` `WaitTimeSeconds`.**
      Evidence: merged via `_mergeOptions` (customOptions/cliOptions override `defaultOptions`) and threaded as `resolveWaitTimeSeconds(sqsEvent, this.options.waitTimeSeconds)` in `_sqsEvent`; test `#123 configured waitTimeSeconds reaches the receiveMessage WaitTimeSeconds param` (15 -> 15) passes.
- [x] **When the configured `waitTimeSeconds` is delivered as a string (YAML/CLI), the plugin shall coerce it to a number before use.**
      Evidence: `coerceWaitTimeSeconds` uses `Number()` like the `enabled` flag (#222); tests `#123 coerceWaitTimeSeconds coerces a numeric string via Number()` and `#123 a string waitTimeSeconds option is coerced before reaching receiveMessage` (`'12'` -> 12) pass.
- [x] **The plugin shall clamp the resolved wait to the SQS long-poll range `[0, 20]` seconds.**
      Evidence: `clamp(0, SQS_MAX_WAIT_TIME_SECONDS, ...)`; tests `#123 coerceWaitTimeSeconds clamps to the SQS long-poll range [0, 20]` (300 -> 20, -3 -> 0) pass.
- [x] **When the configured value is non-finite / nil / empty, the plugin shall fall back to the 5s default and never emit `NaN`.**
      Evidence: test `#123 coerceWaitTimeSeconds falls back to 5 for non-numeric / nil input` (`'oops'`/`undefined`/`null`/`''` -> 5) passes; helper is pure and total.
- [x] **Where a `sqs` event sets its own `maximumBatchingWindow`, the plugin shall use that per-queue value in preference to the configured default.**
      Evidence: `resolveWaitTimeSeconds` short-circuits on a finite `maximumBatchingWindow`; tests `#123 resolveWaitTimeSeconds: per-event maximumBatchingWindow still wins over the options default` and `#123 per-event maximumBatchingWindow overrides the configured waitTimeSeconds at the receiveMessage call` (window 8 over default 15 -> 8) pass.
- [x] **The behavior shall be documented.** Evidence: package `README.md` documents `waitTimeSeconds` (range `0-20`, default 5, CLI flag) and the per-event override precedence.

All 99 tests in `packages/serverless-offline-sqs/test/index.js` pass (12 new `#123` cases).

## Credits

- Reported & bisected: @zoellner (#123)
- Regression author who agreed in-thread to expose it as config: @esetnik (40efaf9)

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
