### PR TITLE
feat(serverless-offline-dynamodb-streams): restart checkpoint, no TRI…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ logs/
 .serverless
 *.log
 
+# serverless-offline-dynamodb-streams restart checkpoint (#178)
+.serverless-offline-dynamodb-streams.json
+
 # Webpack directories
 .webpack
 

--- a/packages/serverless-offline-dynamodb-streams/README.md
+++ b/packages/serverless-offline-dynamodb-streams/README.md
@@ -5,6 +5,7 @@ This Serverless-offline-dynamodb-streams plugin emulates AWS λ and DynamoDBStre
 *Features*:
 - [Serverless Webpack](https://github.com/serverless-heaven/serverless-webpack/) support.
 - DynamoDBStreams configurations: batchsize and startingPosition.
+- Restart checkpoint: records already processed before a restart are not re-delivered (#178).
 
 ## Serverless Framework v4
 
@@ -79,3 +80,34 @@ functions:
           type: dynamodb
           tableName: myTable
 ```
+
+## Restart checkpoint (#178)
+
+To match production DynamoDB-stream semantics, the plugin persists a per-shard restart
+checkpoint. After each handler invocation **resolves**, the sequence number of the last
+record in that batch is written to a small state file. On the next start the plugin
+resumes **after** the saved sequence number (`AFTER_SEQUENCE_NUMBER`) for each shard, so
+records already processed before a restart are **not** re-delivered — even with
+`startingPosition: TRIM_HORIZON`. With no saved checkpoint (cold start) the configured
+`startingPosition` (`LATEST` / `TRIM_HORIZON`) is honored as before.
+
+The state file defaults to `.serverless-offline-dynamodb-streams.json` in the working
+directory and is gitignored. Override its path with the `checkpointFile` custom option
+(absolute, or relative to the working directory):
+
+```yml
+custom:
+  serverless-offline-dynamodb-streams:
+    checkpointFile: .cache/ddb-streams-checkpoint.json
+```
+
+A missing parent directory is created automatically, and a missing or malformed state
+file is treated as a clean cold start (no error).
+
+**Delivery boundary (at-most-once across a restart).** The checkpoint advances *only
+after* the handler resolves, so a record is never marked done before it has been
+processed. The trade-off is at-most-once **for the in-flight batch across a hard crash**:
+if the process is killed *after* the handler ran but *before* its checkpoint reached
+disk, that batch is re-delivered on restart (at-least-once); if it is killed *while* the
+handler is running, that batch is also re-delivered. Handlers should therefore be
+idempotent, exactly as AWS recommends for real stream consumers.

--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -19,6 +19,7 @@
     "src/dynamodb-streams-event-definition.js",
     "src/resolve-arn.js",
     "src/filter-patterns.js",
+    "src/checkpoint-store.js",
     "NOTICE"
   ],
   "author": "Arthur Weber @godu",

--- a/packages/serverless-offline-dynamodb-streams/src/checkpoint-store.js
+++ b/packages/serverless-offline-dynamodb-streams/src/checkpoint-store.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const {getOr, isString, isEmpty} = require('lodash/fp');
+
+// #178 (ddb-streams-checkpoint): persist a per-shard restart checkpoint so a restart
+// resumes AFTER the last record handed to (and processed by) the lambda handler,
+// instead of replaying the whole shard from TRIM_HORIZON on every offline restart.
+//
+// State shape (gitignored JSON file):
+//   { "<streamArn>::<shardId>": "<sequenceNumber>", ... }
+// The key namespaces the sequence number by stream so distinct tables/streams never
+// collide. Everything in this module is pure except the two thin I/O wrappers
+// (loadState / saveState) at the bottom; the decision logic is pure and unit-tested.
+
+const DEFAULT_STATE_FILE = '.serverless-offline-dynamodb-streams.json';
+
+// Build the namespaced state key for a (streamArn, shardId) pair. Pure.
+const checkpointKey = (streamArn, shardId) => `${streamArn}::${shardId}`;
+
+// Read the saved sequence number for a shard from a state map, or undefined when
+// none is recorded. Pure; tolerates a null/undefined state map.
+const getCheckpoint = (state, streamArn, shardId) =>
+  getOr(undefined, [checkpointKey(streamArn, shardId)], state);
+
+// Return a NEW state map with the shard's checkpoint advanced to sequenceNumber.
+// Non-mutating. A nil/empty sequenceNumber is ignored (returns the state unchanged)
+// so a drain sentinel or empty batch never clobbers a real checkpoint.
+const setCheckpoint = (state, streamArn, shardId, sequenceNumber) =>
+  isEmpty(sequenceNumber) || !isString(sequenceNumber)
+    ? {...state}
+    : {...state, [checkpointKey(streamArn, shardId)]: sequenceNumber};
+
+// Decide the readable-stream iterator options for a shard, given any saved checkpoint.
+//
+// - No saved checkpoint  -> honor the configured startingPosition via `iterator`
+//   (LATEST / TRIM_HORIZON), the original cold-start behavior.
+// - Saved checkpoint      -> resume AFTER that sequence number (AFTER_SEQUENCE_NUMBER),
+//   so already-processed records are NOT re-delivered — even under TRIM_HORIZON (#178).
+//
+// `iterator` MUST be omitted when resuming: the readable gives `options.iterator`
+// precedence over `startAfter`, so leaving it set would defeat the resume. Pure.
+const resolveIteratorOptions = (state, streamArn, shardId, startingPosition) => {
+  const sequenceNumber = getCheckpoint(state, streamArn, shardId);
+  return isEmpty(sequenceNumber) ? {iterator: startingPosition} : {startAfter: sequenceNumber};
+};
+
+// Resolve the absolute path of the state file from a (possibly relative) configured
+// path, anchored at the given working directory. Pure.
+const resolveStateFilePath = (stateFile, cwd) => {
+  const file = isEmpty(stateFile) ? DEFAULT_STATE_FILE : stateFile;
+  return path.isAbsolute(file) ? file : path.join(cwd, file);
+};
+
+// --- I/O edges (the only impure functions in this module) ------------------
+
+// Load the persisted state map from disk. Missing file or malformed JSON yields an
+// empty map rather than throwing — a corrupt/absent checkpoint must never crash
+// offline startup, it just means "cold start". #178 EARS4: no ENOENT spam.
+const loadState = stateFilePath => {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(stateFilePath));
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (err) {
+    return {};
+  }
+};
+
+// Persist the state map to disk, creating the parent directory if it is missing
+// (#178 EARS4: a missing checkpoint dir is created, no ENOENT). Best-effort: a write
+// failure is surfaced to the caller, which logs it without aborting the stream.
+const saveState = (stateFilePath, state) => {
+  fs.mkdirSync(path.dirname(stateFilePath), {recursive: true});
+  fs.writeFileSync(stateFilePath, JSON.stringify(state, null, 2), 'utf8');
+};
+
+module.exports = {
+  DEFAULT_STATE_FILE,
+  checkpointKey,
+  getCheckpoint,
+  setCheckpoint,
+  resolveIteratorOptions,
+  resolveStateFilePath,
+  loadState,
+  saveState
+};

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
@@ -2,12 +2,19 @@ const {Writable} = require('stream');
 const DynamodbClient = require('aws-sdk/clients/dynamodb');
 const DynamodbStreamsClient = require('aws-sdk/clients/dynamodbstreams');
 const DynamodbStreamsReadable = require('dynamodb-streams-readable');
-const {assign, isEmpty} = require('lodash/fp');
+const {assign, isEmpty, last, get} = require('lodash/fp');
 
 const {normalizeLog} = require('./log');
 const DynamodbStreamsEventDefinition = require('./dynamodb-streams-event-definition');
 const DynamodbStreamsEvent = require('./dynamodb-streams-event');
 const {filterRecords} = require('./filter-patterns');
+const {
+  resolveIteratorOptions,
+  resolveStateFilePath,
+  setCheckpoint,
+  loadState,
+  saveState
+} = require('./checkpoint-store');
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -20,6 +27,11 @@ const assertStreamEnabled = (tableName, latestStreamArn) => {
   if (!latestStreamArn) throw new Error(`Table ${tableName} does not have streams enabled`);
   return latestStreamArn;
 };
+
+// #178 (ddb-streams-checkpoint): the sequence number of the LAST record in a chunk —
+// the high-water mark the handler has processed up to. `undefined` for an empty/sentinel
+// chunk so the caller skips advancing the checkpoint. Pure.
+const chunkSequenceNumber = chunk => get(['dynamodb', 'SequenceNumber'], last(chunk));
 
 class DynamodbStreams {
   constructor(lambda, options, log) {
@@ -34,6 +46,13 @@ class DynamodbStreams {
     this.streamsClient = new DynamodbStreamsClient(this.options);
 
     this.readables = [];
+
+    // #178 (ddb-streams-checkpoint): resolve and load the restart checkpoint once. The
+    // configured `checkpointFile` (custom option) is anchored at process cwd; a missing
+    // file is a clean cold start (loadState returns {}). The in-memory map is the single
+    // source of truth during the run and is persisted after each handler completes.
+    this.checkpointFile = resolveStateFilePath(this.options.checkpointFile, process.cwd());
+    this.checkpointState = loadState(this.checkpointFile);
   }
 
   create(events) {
@@ -101,13 +120,25 @@ class DynamodbStreams {
       .promise();
 
     shards.forEach(({ShardId: shardId}) => {
+      // #178 (ddb-streams-checkpoint): pick the iterator from any saved checkpoint —
+      // a resume yields {startAfter: seq} (NOT an `iterator`) so already-processed
+      // records are never re-delivered, even under TRIM_HORIZON; a cold start yields the
+      // configured starting position. The readable gives `iterator` precedence over
+      // `startAfter`, which is exactly why the resume path omits `iterator`.
+      const iteratorOptions = resolveIteratorOptions(
+        this.checkpointState,
+        streamArn,
+        shardId,
+        startingPosition
+      );
+
       const readable = DynamodbStreamsReadable(
         this.streamsClient,
         streamArn,
         assign(dynamodbStreamsEvent, {
+          ...iteratorOptions,
           shardId,
-          limit: batchSize,
-          iterator: startingPosition
+          limit: batchSize
         })
       );
 
@@ -138,7 +169,15 @@ class DynamodbStreams {
           };
 
           task(maximumRetryAttempts - 1)
-            .then(() => cb())
+            .then(() => {
+              // #178: advance the checkpoint to the LAST record of the FULL chunk only
+              // AFTER the handler has resolved (at-most-once: a crash before this line
+              // re-delivers the in-flight batch on restart — documented in the README).
+              // We use the full-chunk sequence number (not the filtered subset) so a
+              // batch fully dropped by filterPatterns still moves the cursor forward.
+              this._advanceCheckpoint(streamArn, shardId, chunkSequenceNumber(chunk));
+              return cb();
+            })
             .catch(cb);
         }
       });
@@ -149,7 +188,23 @@ class DynamodbStreams {
       this.readables.push(readable);
     });
   }
+
+  // #178 (ddb-streams-checkpoint): persist the per-shard high-water mark. Thin I/O edge:
+  // updates the in-memory map (pure setCheckpoint) then best-effort writes it. A write
+  // failure is logged, never thrown — losing a checkpoint must not break the stream.
+  _advanceCheckpoint(streamArn, shardId, sequenceNumber) {
+    if (isEmpty(sequenceNumber)) return;
+
+    this.checkpointState = setCheckpoint(this.checkpointState, streamArn, shardId, sequenceNumber);
+
+    try {
+      saveState(this.checkpointFile, this.checkpointState);
+    } catch (err) {
+      this.log.warning(`ddb-streams: failed to persist checkpoint: ${err.message}`);
+    }
+  }
 }
 
 module.exports = DynamodbStreams;
 module.exports.assertStreamEnabled = assertStreamEnabled;
+module.exports.chunkSequenceNumber = chunkSequenceNumber;

--- a/packages/serverless-offline-dynamodb-streams/test/index.js
+++ b/packages/serverless-offline-dynamodb-streams/test/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const test = require('ava');
@@ -6,9 +7,19 @@ const test = require('ava');
 const {defaultLog, normalizeLog} = require('../src/log');
 const DynamodbStreamsEvent = require('../src/dynamodb-streams-event');
 const DynamodbStreamsEventDefinition = require('../src/dynamodb-streams-event-definition');
-const {assertStreamEnabled} = require('../src/dynamodb-streams');
+const {assertStreamEnabled, chunkSequenceNumber} = require('../src/dynamodb-streams');
 const {resolveTableName} = require('../src/resolve-arn');
 const {recordMatchesFilterPatterns, filterRecords} = require('../src/filter-patterns');
+const {
+  DEFAULT_STATE_FILE,
+  checkpointKey,
+  getCheckpoint,
+  setCheckpoint,
+  resolveIteratorOptions,
+  resolveStateFilePath,
+  loadState,
+  saveState
+} = require('../src/checkpoint-store');
 
 const LOG_LEVELS = ['debug', 'info', 'notice', 'warning', 'error', 'success'];
 
@@ -345,4 +356,188 @@ test('recordMatchesFilterPatterns/filterRecords do not mutate inputs', t => {
   filterRecords(patterns, records);
   t.deepEqual(patterns, patternsBefore);
   t.deepEqual(records, recordsBefore);
+});
+
+// ---------------------------------------------------------------------------
+// checkpoint-store (#178 ddb-streams-checkpoint)
+//
+// Deterministic, docker-free unit coverage of the restart checkpoint. The
+// TRIM_HORIZON no-replay guarantee (EARS1) is asserted here as a pure decision
+// on the iterator options, so the regression runs in CI behind pretest:unit
+// (EARS2) without needing DynamoDB Local.
+// ---------------------------------------------------------------------------
+
+const STREAM_ARN = 'arn:aws:dynamodb:eu-west-1:000000000000:table/orders/stream/2024';
+const OTHER_STREAM_ARN = 'arn:aws:dynamodb:eu-west-1:000000000000:table/users/stream/2024';
+
+test('checkpointKey namespaces the sequence number by stream arn + shard', t => {
+  t.is(checkpointKey(STREAM_ARN, 'shardId-1'), `${STREAM_ARN}::shardId-1`);
+  t.not(checkpointKey(STREAM_ARN, 'shardId-1'), checkpointKey(OTHER_STREAM_ARN, 'shardId-1'));
+});
+
+test('getCheckpoint returns the saved sequence number for a (stream, shard)', t => {
+  const state = {[checkpointKey(STREAM_ARN, 'shardId-1')]: '111'};
+  t.is(getCheckpoint(state, STREAM_ARN, 'shardId-1'), '111');
+});
+
+test('getCheckpoint returns undefined when nothing is recorded (incl. null state)', t => {
+  t.is(getCheckpoint({}, STREAM_ARN, 'shardId-1'), undefined);
+  t.is(getCheckpoint(null, STREAM_ARN, 'shardId-1'), undefined);
+  t.is(getCheckpoint(undefined, STREAM_ARN, 'shardId-1'), undefined);
+});
+
+test('getCheckpoint does not cross streams (per-stream isolation)', t => {
+  const state = {[checkpointKey(STREAM_ARN, 'shardId-1')]: '111'};
+  t.is(getCheckpoint(state, OTHER_STREAM_ARN, 'shardId-1'), undefined);
+});
+
+test('setCheckpoint advances a shard without mutating the input state', t => {
+  const state = {};
+  const next = setCheckpoint(state, STREAM_ARN, 'shardId-1', '222');
+  t.is(getCheckpoint(next, STREAM_ARN, 'shardId-1'), '222');
+  t.deepEqual(state, {}, 'original state untouched');
+  t.not(next, state, 'returns a new object');
+});
+
+test('setCheckpoint overwrites an earlier checkpoint for the same shard', t => {
+  const state = setCheckpoint({}, STREAM_ARN, 'shardId-1', '100');
+  const next = setCheckpoint(state, STREAM_ARN, 'shardId-1', '200');
+  t.is(getCheckpoint(next, STREAM_ARN, 'shardId-1'), '200');
+});
+
+test('setCheckpoint ignores a nil/empty/non-string sequence number (no clobber)', t => {
+  const state = setCheckpoint({}, STREAM_ARN, 'shardId-1', '100');
+  t.is(
+    getCheckpoint(
+      setCheckpoint(state, STREAM_ARN, 'shardId-1', undefined),
+      STREAM_ARN,
+      'shardId-1'
+    ),
+    '100'
+  );
+  t.is(
+    getCheckpoint(setCheckpoint(state, STREAM_ARN, 'shardId-1', null), STREAM_ARN, 'shardId-1'),
+    '100'
+  );
+  t.is(
+    getCheckpoint(setCheckpoint(state, STREAM_ARN, 'shardId-1', ''), STREAM_ARN, 'shardId-1'),
+    '100'
+  );
+});
+
+// EARS1: a TRIM_HORIZON restart with a saved checkpoint must resume AFTER the
+// processed sequence number, NOT replay from the horizon.
+test('resolveIteratorOptions: TRIM_HORIZON with a saved checkpoint resumes AFTER it, no replay (#178 EARS1)', t => {
+  const state = setCheckpoint({}, STREAM_ARN, 'shardId-1', '111');
+  const options = resolveIteratorOptions(state, STREAM_ARN, 'shardId-1', 'TRIM_HORIZON');
+
+  t.deepEqual(options, {startAfter: '111'});
+  t.is(options.iterator, undefined, 'iterator must be omitted so startAfter wins in the readable');
+});
+
+test('resolveIteratorOptions: LATEST with a saved checkpoint also resumes AFTER it (#178)', t => {
+  const state = setCheckpoint({}, STREAM_ARN, 'shardId-1', '999');
+  t.deepEqual(resolveIteratorOptions(state, STREAM_ARN, 'shardId-1', 'LATEST'), {
+    startAfter: '999'
+  });
+});
+
+test('resolveIteratorOptions: no checkpoint -> honor the configured startingPosition (cold start)', t => {
+  t.deepEqual(resolveIteratorOptions({}, STREAM_ARN, 'shardId-1', 'TRIM_HORIZON'), {
+    iterator: 'TRIM_HORIZON'
+  });
+  t.deepEqual(resolveIteratorOptions({}, STREAM_ARN, 'shardId-1', 'LATEST'), {iterator: 'LATEST'});
+});
+
+test('resolveStateFilePath defaults to the gitignored state file anchored at cwd', t => {
+  t.is(resolveStateFilePath(undefined, '/srv/app'), path.join('/srv/app', DEFAULT_STATE_FILE));
+  t.is(DEFAULT_STATE_FILE, '.serverless-offline-dynamodb-streams.json');
+});
+
+test('resolveStateFilePath honors an absolute configured path as-is', t => {
+  t.is(resolveStateFilePath('/var/lib/cp.json', '/srv/app'), '/var/lib/cp.json');
+});
+
+test('resolveStateFilePath resolves a relative configured path against cwd', t => {
+  t.is(resolveStateFilePath('.cache/cp.json', '/srv/app'), path.join('/srv/app', '.cache/cp.json'));
+});
+
+// EARS4: loading a missing file is a clean cold start (no throw, no ENOENT spam).
+test('loadState returns an empty map for a missing file (no throw, EARS4)', t => {
+  const missing = path.join(os.tmpdir(), `ddb-cp-missing-${Date.now()}.json`);
+  t.notThrows(() => loadState(missing));
+  t.deepEqual(loadState(missing), {});
+});
+
+test('loadState returns an empty map for malformed JSON (cold start, never crash)', t => {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ddb-cp-')), 'corrupt.json');
+  fs.writeFileSync(file, '{not json', 'utf8');
+  t.deepEqual(loadState(file), {});
+});
+
+// EARS4: saving into a not-yet-existing directory creates it (no ENOENT).
+test('saveState creates a missing checkpoint dir and round-trips the state (EARS4)', t => {
+  const dir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ddb-cp-')), 'nested', 'deeper');
+  const file = path.join(dir, DEFAULT_STATE_FILE);
+  const state = setCheckpoint({}, STREAM_ARN, 'shardId-1', '111');
+
+  t.false(fs.existsSync(dir), 'precondition: dir does not exist yet');
+  t.notThrows(() => saveState(file, state));
+  t.true(fs.existsSync(dir), 'missing dir was created');
+  t.deepEqual(loadState(file), state, 'persisted state round-trips');
+});
+
+// chunkSequenceNumber: the high-water mark advanced after the handler resolves.
+test('chunkSequenceNumber returns the SequenceNumber of the last record of a chunk', t => {
+  const chunk = [
+    {dynamodb: {SequenceNumber: '100'}},
+    {dynamodb: {SequenceNumber: '101'}},
+    {dynamodb: {SequenceNumber: '111'}}
+  ];
+  t.is(chunkSequenceNumber(chunk), '111');
+});
+
+test('chunkSequenceNumber is undefined for an empty/nil chunk (no checkpoint advance)', t => {
+  t.is(chunkSequenceNumber([]), undefined);
+  t.is(chunkSequenceNumber(undefined), undefined);
+  t.is(chunkSequenceNumber(null), undefined);
+});
+
+// EARS1 source guard: the readable must NOT be wired with an unconditional
+// `iterator: startingPosition` (that ignored any saved checkpoint and replayed
+// from TRIM_HORIZON). It must route through resolveIteratorOptions.
+test('src/dynamodb-streams.js resumes via the checkpoint store, not an unconditional iterator (#178 EARS1)', t => {
+  const source = readSource('dynamodb-streams.js');
+
+  t.false(
+    /iterator:\s*startingPosition/.test(source),
+    'must not hard-wire iterator: startingPosition (that replays from TRIM_HORIZON)'
+  );
+  t.true(source.includes('resolveIteratorOptions'));
+  t.true(source.includes('_advanceCheckpoint'));
+});
+
+// EARS3 source guard: the checkpoint advances only inside the post-resolve `.then`,
+// never before the handler runs.
+test('src/dynamodb-streams.js advances the checkpoint only after the handler resolves (#178 EARS3)', t => {
+  const source = readSource('dynamodb-streams.js');
+  const thenIdx = source.indexOf('.then(() => {');
+  const advanceIdx = source.indexOf('this._advanceCheckpoint(streamArn, shardId');
+
+  t.true(advanceIdx > -1 && thenIdx > -1);
+  t.true(advanceIdx > thenIdx, 'the advance call lives inside the post-handler .then');
+});
+
+// End-to-end of the pure store: process records, restart, and assert no replay.
+test('checkpoint round-trip: a restart resumes AFTER the last processed record (#178 EARS1+EARS3)', t => {
+  // First run processes up to sequence 111 and persists it.
+  const afterFirstRun = setCheckpoint({}, STREAM_ARN, 'shardId-1', '111');
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ddb-cp-')), DEFAULT_STATE_FILE);
+  saveState(file, afterFirstRun);
+
+  // Restart: reload state and decide the iterator for TRIM_HORIZON.
+  const reloaded = loadState(file);
+  const options = resolveIteratorOptions(reloaded, STREAM_ARN, 'shardId-1', 'TRIM_HORIZON');
+
+  t.deepEqual(options, {startAfter: '111'}, 'resumes after 111, does not replay 0..111');
 });


### PR DESCRIPTION
…M_HORIZON replay (#178)

Persist a per-shard {streamArn::shardId -> sequenceNumber} checkpoint to a gitignored JSON state file (default .serverless-offline-dynamodb-streams.json, overridable via the `checkpointFile` custom option). On start, resume each shard AFTER its saved sequence number (AFTER_SEQUENCE_NUMBER) instead of replaying from the configured startingPosition — so records processed before a restart are not re-delivered, even under TRIM_HORIZON.

The checkpoint advances only AFTER the handler resolves (at-most-once boundary across a hard crash, documented in the README). A missing checkpoint dir is created (mkdir recursive) and a missing/malformed state file is a clean cold start (no ENOENT).

All decision logic lives in a pure, exported checkpoint-store helper module (checkpointKey / getCheckpoint / setCheckpoint / resolveIteratorOptions / resolveStateFilePath) covered by deterministic AVA unit tests that run in CI behind pretest:unit — no DynamoDB Local required. Includes the TRIM_HORIZON no-replay regression assertion and source guards for the wiring.