### PR TITLE
feat: migrate all plugins from aws-sdk v2 to @aws-sdk v3 (#248, #252)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19430,6 +19430,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kinesis": "^3.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
         "kinesis-readable": "^1.2.0",
         "lodash": "^4.17.21"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19357,6 +19357,7 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.0.0",
         "@aws-sdk/client-dynamodb-streams": "^3.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
         "uuid": "^9.0.0"
       },
       "engines": {
@@ -19394,6 +19395,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.0.0",
         "@aws-sdk/client-dynamodb-streams": "^3.0.0",
+        "@smithy/node-http-handler": "^4.0.0",
         "dynamodb-streams-readable": "^3.0.0",
         "lodash": "^4.17.21",
         "serverless-offline-eventbridge": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,50 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1073.0.tgz",
+      "integrity": "sha512-2GUPeI0drcms+LOoSC2DfVLCUWQxjjUm4jN08MrVh40XnIRQZ9PxCjFCqAj6yMRXPAzze925MMXEXBQC7IS6jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/dynamodb-codec": "^3.973.22",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.19",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb-streams": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb-streams/-/client-dynamodb-streams-3.1073.0.tgz",
+      "integrity": "sha512-y/hkMORkrIRgctKhwRzgTh+ntk1FUYRUS68jYSytxGaTJV7xFq+dTScuxINZh4Qs1M7opHOx6y6uGKqfO3zJKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-eventbridge": {
       "version": "3.1073.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1073.0.tgz",
@@ -236,6 +280,27 @@
       "version": "3.1073.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1073.0.tgz",
       "integrity": "sha512-TEovDL6IPOiThcSWj0xVJe0Mffc06xFD1xEry+kAREra0d8ArxGFnYeCRBOxQkGpw0H3z0T8STWxw73ibkm/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.1073.0.tgz",
+      "integrity": "sha512-wqyICoxkNL9B3WQW3uk21836liP/zGYwjkJR5B/TE1xtt2QJ0+asBWbFfTyCA+eXE+59Ls6RuEVXuTak7fDepw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -288,6 +353,28 @@
         "@aws-sdk/middleware-flexible-checksums": "^3.974.32",
         "@aws-sdk/middleware-sdk-s3": "^3.972.53",
         "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.1073.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1073.0.tgz",
+      "integrity": "sha512-Is7xWCAOQP9oNqFktcjcBJhZ171u7/Ewtnoxh5qL0CiL/v+LxDi2UK/0KTu0jiZNWxiMeVznjLHktVGyqnl+Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.22",
+        "@aws-sdk/credential-provider-node": "^3.972.57",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.31",
         "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -510,6 +597,50 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.22.tgz",
+      "integrity": "sha512-QBs7/nWHsPA0wTEqhU5iPgaDjeZzQHhmwJr6Q0f56rW3Fk8ExJQgXFzEg/l48iDwJVUIMLjPqhw7dNP3cShUxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.22",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.8.tgz",
+      "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.19.tgz",
+      "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.8",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
       "version": "3.974.32",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.32.tgz",
@@ -546,6 +677,21 @@
       "dependencies": {
         "@aws-sdk/core": "^3.974.22",
         "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.31.tgz",
+      "integrity": "sha512-56ifsBmK9bLn5EE/t6c0nmjOB1BO8cJDLkA1VOlsN1GR85ROqnaCwVDspqcwsLaBDgPlwyYNedoDIoT3t6Ho1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@aws-sdk/types": "^3.973.13",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -12115,6 +12261,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -13628,6 +13783,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -19190,7 +19351,12 @@
     "packages/dynamodb-streams-readable": {
       "version": "3.0.0",
       "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/client-dynamodb-streams": "^3.0.0",
         "uuid": "^9.0.0"
       },
       "engines": {
@@ -19216,7 +19382,6 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -19227,9 +19392,11 @@
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/client-dynamodb-streams": "^3.0.0",
         "dynamodb-streams-readable": "^3.0.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "serverless-offline-eventbridge": "^1.0.0"
       },
       "devDependencies": {
         "serverless-offline": "^13"
@@ -19245,7 +19412,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
+        "@aws-sdk/client-sqs": "^3.0.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -19262,7 +19429,7 @@
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
+        "@aws-sdk/client-kinesis": "^3.0.0",
         "kinesis-readable": "^1.2.0",
         "lodash": "^4.17.21"
       },
@@ -19280,7 +19447,6 @@
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
         "figures": "^5.0.0",
         "lodash": "^4.17.21",
         "minio": "^8.0.7"
@@ -19327,7 +19493,7 @@
       "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "aws-sdk": "^2.1234.0",
+        "@aws-sdk/client-sqs": "^3.0.0",
         "lodash": "^4.17.21",
         "p-queue": "^6.6.2"
       },

--- a/packages/dynamodb-streams-readable/package.json
+++ b/packages/dynamodb-streams-readable/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/client-dynamodb-streams": "^3.0.0",
+    "@smithy/node-http-handler": "^4.0.0",
     "uuid": "^9.0.0"
   },
   "keywords": [

--- a/packages/dynamodb-streams-readable/package.json
+++ b/packages/dynamodb-streams-readable/package.json
@@ -14,6 +14,7 @@
   "files": [
     "src/index.js",
     "src/stream-helpers.js",
+    "src/callback-adapter.js",
     "src/log.js"
   ],
   "author": "Arthur Weber @godu",
@@ -25,6 +26,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.0.0",
     "uuid": "^9.0.0"
   },
   "keywords": [

--- a/packages/dynamodb-streams-readable/src/callback-adapter.js
+++ b/packages/dynamodb-streams-readable/src/callback-adapter.js
@@ -1,0 +1,32 @@
+// #248 (aws-sdk v3): `kinesis-readable` drives the AWS client through the aws-sdk v2 CALLBACK
+// contract — `client.describeStream(params, cb)`, `client.getShardIterator(params, cb)`,
+// `client.getRecords(params, cb)`. The @aws-sdk v3 client only exposes the promise-based
+// `client.send(new Command(params))`. Rather than fork the readable, wrap the v3 client in a thin
+// promise->callback shim that re-exposes exactly the v2 callback-style methods the readable expects,
+// leaving the readable's pure logic untouched.
+
+// toCallbackMethod(client, Command) -> (params, callback) => Promise
+// Pure factory: returns a node-style callback function that sends the v3 command and forwards
+// (err, data) to the callback. Never throws synchronously; a rejected send surfaces as the `err` arg.
+// The send promise is returned (rejection handled in-chain) so it is never floated, and the callback
+// runs exactly once on settlement — mirroring the aws-sdk v2 callback contract kinesis-readable uses.
+const toCallbackMethod = (client, Command) => (params, callback) =>
+  client.send(new Command(params)).then(
+    data => callback(null, data),
+    err => callback(err)
+  );
+
+// buildCallbackClient(client, commandsByMethod) -> {<method>: (params, cb) => void, send}
+// Pure: maps every {methodName: Command} entry to a v2-style callback method bound to `client`, and
+// keeps `send` available for direct v3 use. Does not mutate `client`.
+const buildCallbackClient = (client, commandsByMethod) => {
+  const methods = Object.fromEntries(
+    Object.entries(commandsByMethod).map(([method, Command]) => [
+      method,
+      toCallbackMethod(client, Command)
+    ])
+  );
+  return {...methods, send: (...args) => client.send(...args)};
+};
+
+module.exports = {toCallbackMethod, buildCallbackClient};

--- a/packages/dynamodb-streams-readable/src/index.js
+++ b/packages/dynamodb-streams-readable/src/index.js
@@ -170,7 +170,12 @@ function DynamoDBStreamReadable(client, arn, options) {
         // origin/master latched drain=true here on an absent NextShardIterator; we no longer do.
         iterator = data.NextShardIterator;
 
-        if (data.Records.length === 0) {
+        // #248 (aws-sdk v3): a v3 GetRecords response OMITS `Records` entirely when empty (aws-sdk v2
+        // always returned []). Guard here in the I/O wiring (the pure stream-helpers stay untouched)
+        // so `.length` never reads `undefined` and the empty-batch poll loop below keeps working.
+        const records = getOr([], 'Records', data);
+
+        if (records.length === 0) {
           // #54 (asprouse) / #82 (kalitamih) / #163 (mcopik): an empty batch on an OPEN, non-closed
           // stream must keep polling — even when NextShardIterator is absent (re-describe first).
           if (shouldKeepPolling({closed, sealed})) {

--- a/packages/dynamodb-streams-readable/test/index.js
+++ b/packages/dynamodb-streams-readable/test/index.js
@@ -12,6 +12,7 @@ const {
   GetRecordsCommand,
   GetShardIteratorCommand
 } = require('@aws-sdk/client-dynamodb-streams');
+const {NodeHttpHandler} = require('@smithy/node-http-handler');
 const DynamoDBStreamReadable = require('..');
 const {buildCallbackClient} = require('../src/callback-adapter');
 
@@ -23,7 +24,9 @@ const delay = timeout =>
 const CLIENT_CONFIG = {
   credentials: {accessKeyId: 'local', secretAccessKey: 'local'},
   endpoint: 'http://localhost:8000',
-  region: 'eu-west-1'
+  region: 'eu-west-1',
+  // #248 (aws-sdk v3): force HTTP/1.1 — DynamoDB Local does not speak the v3 client's default HTTP/2.
+  requestHandler: new NodeHttpHandler()
 };
 
 // #248 (aws-sdk v3): DynamoDBStreamReadable drives the streams client through the aws-sdk v2 callback

--- a/packages/dynamodb-streams-readable/test/index.js
+++ b/packages/dynamodb-streams-readable/test/index.js
@@ -1,38 +1,57 @@
 const test = require('ava');
 const {v4: uuid} = require('uuid');
-const DynamoDB = require('aws-sdk/clients/dynamodb');
-const DynamoDBStreams = require('aws-sdk/clients/dynamodbstreams');
+const {
+  DynamoDBClient,
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  ScanCommand
+} = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBStreamsClient,
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand
+} = require('@aws-sdk/client-dynamodb-streams');
 const DynamoDBStreamReadable = require('..');
+const {buildCallbackClient} = require('../src/callback-adapter');
 
 const delay = timeout =>
   new Promise(resolve => {
     setTimeout(resolve, timeout);
   });
 
+const CLIENT_CONFIG = {
+  credentials: {accessKeyId: 'local', secretAccessKey: 'local'},
+  endpoint: 'http://localhost:8000',
+  region: 'eu-west-1'
+};
+
+// #248 (aws-sdk v3): DynamoDBStreamReadable drives the streams client through the aws-sdk v2 callback
+// contract; wrap the v3 client in the same promise->callback shim the plugin uses in production.
+const DDB_STREAMS_READABLE_COMMANDS = {
+  describeStream: DescribeStreamCommand,
+  getShardIterator: GetShardIteratorCommand,
+  getRecords: GetRecordsCommand
+};
+
 const batchWriteItem = (dynamodb, tableName, items) =>
-  dynamodb
-    .batchWriteItem({
+  dynamodb.send(
+    new BatchWriteItemCommand({
       RequestItems: {
         [tableName]: items.map(document => ({
           PutRequest: document
         }))
       }
     })
-    .promise();
+  );
 
 test.before(t => {
-  t.context.dynamodb = new DynamoDB({
-    accessKeyId: 'local',
-    secretAccessKey: 'local',
-    endpoint: 'http://localhost:8000',
-    region: 'eu-west-1'
-  });
-  t.context.dynamodbstreams = new DynamoDBStreams({
-    accessKeyId: 'local',
-    secretAccessKey: 'local',
-    endpoint: 'http://localhost:8000',
-    region: 'eu-west-1'
-  });
+  t.context.dynamodb = new DynamoDBClient(CLIENT_CONFIG);
+  // The raw v3 streams client (used by the readable through the callback shim below).
+  t.context.dynamodbstreams = buildCallbackClient(
+    new DynamoDBStreamsClient(CLIENT_CONFIG),
+    DDB_STREAMS_READABLE_COMMANDS
+  );
 });
 
 test.beforeEach(async t => {
@@ -41,8 +60,8 @@ test.beforeEach(async t => {
   const tableName = uuid();
   t.context.tableName = tableName;
 
-  const table = await dynamodb
-    .createTable({
+  const table = await dynamodb.send(
+    new CreateTableCommand({
       TableName: tableName,
       AttributeDefinitions: [
         {
@@ -65,7 +84,7 @@ test.beforeEach(async t => {
         WriteCapacityUnits: 1
       }
     })
-    .promise();
+  );
 
   t.context.table = table;
 });
@@ -90,15 +109,13 @@ test.serial('reads records that already exist', async t => {
 
   await batchWriteItem(dynamodb, tableName, documents);
 
-  t.deepEqual(
-    await dynamodb
-      .scan({
-        TableName: tableName,
-        Select: 'COUNT'
-      })
-      .promise(),
-    {Count: documents.length, ScannedCount: documents.length}
+  const {Count, ScannedCount} = await dynamodb.send(
+    new ScanCommand({
+      TableName: tableName,
+      Select: 'COUNT'
+    })
   );
+  t.deepEqual({Count, ScannedCount}, {Count: documents.length, ScannedCount: documents.length});
 
   const readable = DynamoDBStreamReadable(dynamodbstreams, LatestStreamArn, {readInterval: 1});
 

--- a/packages/dynamodb-streams-readable/test/index.js
+++ b/packages/dynamodb-streams-readable/test/index.js
@@ -4,6 +4,7 @@ const {
   DynamoDBClient,
   BatchWriteItemCommand,
   CreateTableCommand,
+  ListTablesCommand,
   ScanCommand
 } = require('@aws-sdk/client-dynamodb');
 const {
@@ -26,7 +27,26 @@ const CLIENT_CONFIG = {
   endpoint: 'http://localhost:8000',
   region: 'eu-west-1',
   // #248 (aws-sdk v3): force HTTP/1.1 — DynamoDB Local does not speak the v3 client's default HTTP/2.
-  requestHandler: new NodeHttpHandler()
+  requestHandler: new NodeHttpHandler(),
+  // #248 (aws-sdk v3): the v3 client defaults to maxAttempts:3 with ~150ms total backoff and gives up
+  // (ECONNRESET "socket hang up") before the cold DynamoDB Local JVM accepts connections — aws-sdk v2
+  // tolerated this. CI runs `nyc ava` right after `docker-compose up -d`, so this test races the cold
+  // emulator. A generous maxAttempts lets the very first request ride out the JVM's cold start.
+  maxAttempts: 20
+};
+
+// #248 (aws-sdk v3): CI does `docker-compose up -d` then immediately `nyc ava`, so this suite races a
+// cold DynamoDB Local that is not yet accepting connections. Poll ListTables (a cheap, side-effect-free
+// call) until the emulator answers, so the per-test CreateTableCommand never hits a dead socket. Bounded
+// by `attempts` so a genuinely down emulator still fails fast instead of hanging the suite.
+const waitForDynamoDB = async (client, attempts = 60, intervalMs = 500) => {
+  try {
+    await client.send(new ListTablesCommand({}));
+  } catch (err) {
+    if (attempts <= 1) throw err;
+    await delay(intervalMs);
+    return waitForDynamoDB(client, attempts - 1, intervalMs);
+  }
 };
 
 // #248 (aws-sdk v3): DynamoDBStreamReadable drives the streams client through the aws-sdk v2 callback
@@ -48,13 +68,15 @@ const batchWriteItem = (dynamodb, tableName, items) =>
     })
   );
 
-test.before(t => {
+test.before(async t => {
   t.context.dynamodb = new DynamoDBClient(CLIENT_CONFIG);
   // The raw v3 streams client (used by the readable through the callback shim below).
   t.context.dynamodbstreams = buildCallbackClient(
     new DynamoDBStreamsClient(CLIENT_CONFIG),
     DDB_STREAMS_READABLE_COMMANDS
   );
+  // Tolerate a cold-started emulator: block until DynamoDB Local answers before any test runs.
+  await waitForDynamoDB(t.context.dynamodb);
 });
 
 test.beforeEach(async t => {

--- a/packages/dynamodb-streams-readable/test/v3-unit.js
+++ b/packages/dynamodb-streams-readable/test/v3-unit.js
@@ -1,0 +1,79 @@
+// Fast unit tests for the aws-sdk v3 migration (#248) — no DynamoDB Local required.
+// The docker-backed integration suite lives in ./index.js; these cover the v3-specific contract
+// (the promise->callback shim and the omitted-Records guard) with plain fakes.
+const test = require('ava');
+const DynamoDBStreamReadable = require('..');
+const {toCallbackMethod, buildCallbackClient} = require('../src/callback-adapter');
+
+class FakeCommand {
+  constructor(params) {
+    this.params = params;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// callback-adapter (#248 promise->callback shim — keeps the readable's pure helpers untouched)
+// ---------------------------------------------------------------------------
+
+test('toCallbackMethod forwards a resolved v3 send as (null, data)', async t => {
+  const client = {send: command => Promise.resolve({echoed: command.params})};
+  const method = toCallbackMethod(client, FakeCommand);
+  const data = await new Promise((resolve, reject) => {
+    method({StreamArn: 's'}, (err, d) => (err ? reject(err) : resolve(d)));
+  });
+  t.deepEqual(data, {echoed: {StreamArn: 's'}});
+});
+
+test('toCallbackMethod forwards a rejected v3 send as the err arg (no throw)', async t => {
+  const boom = new Error('boom');
+  const client = {send: () => Promise.reject(boom)};
+  const method = toCallbackMethod(client, FakeCommand);
+  const err = await new Promise(resolve => {
+    method({}, e => resolve(e));
+  });
+  t.is(err, boom);
+});
+
+test('buildCallbackClient maps each command to a v2-style callback method plus a passthrough send', t => {
+  const wrapped = buildCallbackClient(
+    {send: () => Promise.resolve('ok')},
+    {getRecords: FakeCommand, describeStream: FakeCommand, getShardIterator: FakeCommand}
+  );
+  t.is(typeof wrapped.getRecords, 'function');
+  t.is(typeof wrapped.describeStream, 'function');
+  t.is(typeof wrapped.getShardIterator, 'function');
+  t.is(typeof wrapped.send, 'function');
+});
+
+// ---------------------------------------------------------------------------
+// EARS3 — omitted Records array guard
+// ---------------------------------------------------------------------------
+
+// A v3 GetRecords response OMITS `Records` entirely when empty (aws-sdk v2 always returned []).
+// Driving the readable with a fake callback client whose getRecords returns NO Records key must NOT
+// crash on `undefined.length`; the stream ends cleanly on close().
+test('EARS3: readable tolerates a v3 GetRecords response with an omitted Records array', t => {
+  const fakeClient = {
+    describeStream: (params, cb) => cb(null, {StreamDescription: {Shards: [{ShardId: 'shard-1'}]}}),
+    getShardIterator: (params, cb) => cb(null, {ShardIterator: 'it-0'}),
+    // No `Records` key at all — exactly what v3 returns for an empty batch.
+    getRecords: (params, cb) => cb(null, {NextShardIterator: 'it-1'})
+  };
+
+  const readable = DynamoDBStreamReadable(fakeClient, 'arn:aws:dynamodb:::table/x/stream/y', {
+    readInterval: 1
+  });
+
+  return new Promise((resolve, reject) => {
+    readable
+      .on('data', () => {})
+      .on('error', err => reject(err))
+      .on('end', () => {
+        t.pass();
+        resolve();
+      });
+    // Let a few empty polls happen, then close: a crash on undefined.Records would surface as an
+    // 'error' event and reject before this fires.
+    setTimeout(() => readable.close(), 50);
+  });
+});

--- a/packages/serverless-apigateway-access-logs/package.json
+++ b/packages/serverless-apigateway-access-logs/package.json
@@ -20,7 +20,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
     "lodash": "^4.17.21"
   },
   "keywords": [

--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/client-dynamodb-streams": "^3.0.0",
+    "@smithy/node-http-handler": "^4.0.0",
     "dynamodb-streams-readable": "^3.0.0",
     "lodash": "^4.17.21",
     "serverless-offline-eventbridge": "^1.0.0"

--- a/packages/serverless-offline-dynamodb-streams/package.json
+++ b/packages/serverless-offline-dynamodb-streams/package.json
@@ -14,6 +14,8 @@
   "files": [
     "src/index.js",
     "src/log.js",
+    "src/client-config.js",
+    "src/callback-adapter.js",
     "src/dynamodb-streams.js",
     "src/dynamodb-streams-event.js",
     "src/dynamodb-streams-event-definition.js",
@@ -31,7 +33,8 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.0.0",
     "dynamodb-streams-readable": "^3.0.0",
     "lodash": "^4.17.21",
     "serverless-offline-eventbridge": "^1.0.0"

--- a/packages/serverless-offline-dynamodb-streams/src/callback-adapter.js
+++ b/packages/serverless-offline-dynamodb-streams/src/callback-adapter.js
@@ -1,0 +1,32 @@
+// #248 (aws-sdk v3): `kinesis-readable` drives the AWS client through the aws-sdk v2 CALLBACK
+// contract — `client.describeStream(params, cb)`, `client.getShardIterator(params, cb)`,
+// `client.getRecords(params, cb)`. The @aws-sdk v3 client only exposes the promise-based
+// `client.send(new Command(params))`. Rather than fork the readable, wrap the v3 client in a thin
+// promise->callback shim that re-exposes exactly the v2 callback-style methods the readable expects,
+// leaving the readable's pure logic untouched.
+
+// toCallbackMethod(client, Command) -> (params, callback) => Promise
+// Pure factory: returns a node-style callback function that sends the v3 command and forwards
+// (err, data) to the callback. Never throws synchronously; a rejected send surfaces as the `err` arg.
+// The send promise is returned (rejection handled in-chain) so it is never floated, and the callback
+// runs exactly once on settlement — mirroring the aws-sdk v2 callback contract kinesis-readable uses.
+const toCallbackMethod = (client, Command) => (params, callback) =>
+  client.send(new Command(params)).then(
+    data => callback(null, data),
+    err => callback(err)
+  );
+
+// buildCallbackClient(client, commandsByMethod) -> {<method>: (params, cb) => void, send}
+// Pure: maps every {methodName: Command} entry to a v2-style callback method bound to `client`, and
+// keeps `send` available for direct v3 use. Does not mutate `client`.
+const buildCallbackClient = (client, commandsByMethod) => {
+  const methods = Object.fromEntries(
+    Object.entries(commandsByMethod).map(([method, Command]) => [
+      method,
+      toCallbackMethod(client, Command)
+    ])
+  );
+  return {...methods, send: (...args) => client.send(...args)};
+};
+
+module.exports = {toCallbackMethod, buildCallbackClient};

--- a/packages/serverless-offline-dynamodb-streams/src/client-config.js
+++ b/packages/serverless-offline-dynamodb-streams/src/client-config.js
@@ -1,0 +1,58 @@
+const {isNil, omit} = require('lodash/fp');
+
+// #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
+// defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
+// options into a clean v3 client config so the offline plugins keep working against local emulators.
+
+// A region the v3 client accepts when none was provided. Local emulators (ElasticMQ, sqslite,
+// DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
+const DEFAULT_REGION = 'us-east-1';
+
+// #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
+// `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
+// "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
+// neither) key is supplied we omit `credentials` entirely and let the v3 default provider chain run.
+const buildCredentials = options => {
+  const accessKeyId = options ? options.accessKeyId : undefined;
+  const secretAccessKey = options ? options.secretAccessKey : undefined;
+  if (isNil(accessKeyId) || isNil(secretAccessKey)) return undefined;
+  const sessionToken = options ? options.sessionToken : undefined;
+  return {...(isNil(sessionToken) ? {} : {sessionToken}), accessKeyId, secretAccessKey};
+};
+
+// #248 (aws-sdk v3): a custom `endpoint` without `provider.region` must still work. v2 fell back to a
+// default region; v3 throws "Region is missing". When an endpoint is set and no region is supplied,
+// inject a default so signing succeeds against the local emulator.
+const resolveRegion = options => {
+  const region = options ? options.region : undefined;
+  if (!isNil(region)) return region;
+  return options && options.endpoint ? DEFAULT_REGION : undefined;
+};
+
+// buildClientConfig(options) -> a v3-ready client config. Pure + non-mutating: never sends a
+// half-empty credentials object, and never leaves the region undefined when an endpoint is set.
+// The original `accessKeyId`/`secretAccessKey`/`sessionToken` scalars are dropped (v3 reads them
+// from `credentials`); every other option (endpoint, maxAttempts, ...) is passed through untouched.
+const buildClientConfig = (options = {}) => {
+  const base = omit(['accessKeyId', 'secretAccessKey', 'sessionToken', 'region'], options);
+  const credentials = buildCredentials(options);
+  const region = resolveRegion(options);
+  return {
+    ...base,
+    ...(isNil(region) ? {} : {region}),
+    ...(isNil(credentials) ? {} : {credentials})
+  };
+};
+
+// #248 (aws-sdk v3): a v3 GetRecords/ReceiveMessage response OMITS the array key entirely when empty
+// (v2 always returned `[]`). Guard so `response.Records.length` / `.Messages.length` never throws on
+// `undefined`. Pure: returns the array unchanged when present, `[]` when nil.
+const ensureArray = value => (isNil(value) ? [] : value);
+
+module.exports = {
+  DEFAULT_REGION,
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray
+};

--- a/packages/serverless-offline-dynamodb-streams/src/client-config.js
+++ b/packages/serverless-offline-dynamodb-streams/src/client-config.js
@@ -1,4 +1,5 @@
 const {isNil, omit} = require('lodash/fp');
+const {NodeHttpHandler} = require('@smithy/node-http-handler');
 
 // #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
 // defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
@@ -40,7 +41,11 @@ const buildClientConfig = (options = {}) => {
   return {
     ...base,
     ...(isNil(region) ? {} : {region}),
-    ...(isNil(credentials) ? {} : {credentials})
+    ...(isNil(credentials) ? {} : {credentials}),
+    // #248 (aws-sdk v3): @aws-sdk/client-dynamodb and -dynamodb-streams default their request handler to
+    // NodeHttp2Handler (real DynamoDB serves HTTP/2). DynamoDB Local speaks only HTTP/1.1, so the default
+    // handler times out against the local emulator. Force HTTP/1.1; a user-supplied requestHandler wins.
+    requestHandler: base.requestHandler || new NodeHttpHandler()
   };
 };
 

--- a/packages/serverless-offline-dynamodb-streams/src/client-config.js
+++ b/packages/serverless-offline-dynamodb-streams/src/client-config.js
@@ -9,6 +9,13 @@ const {NodeHttpHandler} = require('@smithy/node-http-handler');
 // DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
 const DEFAULT_REGION = 'us-east-1';
 
+// #248 (aws-sdk v3): v3 clients default to maxAttempts:3 with ~150ms total backoff and give up
+// (ECONNRESET "socket hang up") before a freshly-started local emulator (the DynamoDB Local JVM)
+// finishes booting — aws-sdk v2 tolerated this. A generous default lets the offline plugin ride out
+// the emulator's cold start. A user-supplied `maxAttempts` still wins (it survives in `base` and is
+// spread after this default below).
+const DEFAULT_MAX_ATTEMPTS = 20;
+
 // #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
 // `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
 // "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
@@ -42,6 +49,8 @@ const buildClientConfig = (options = {}) => {
     ...base,
     ...(isNil(region) ? {} : {region}),
     ...(isNil(credentials) ? {} : {credentials}),
+    // Cold-start default; a user-supplied `maxAttempts` (kept in `base`) still wins.
+    maxAttempts: isNil(base.maxAttempts) ? DEFAULT_MAX_ATTEMPTS : base.maxAttempts,
     // #248 (aws-sdk v3): @aws-sdk/client-dynamodb and -dynamodb-streams default their request handler to
     // NodeHttp2Handler (real DynamoDB serves HTTP/2). DynamoDB Local speaks only HTTP/1.1, so the default
     // handler times out against the local emulator. Force HTTP/1.1; a user-supplied requestHandler wins.
@@ -56,6 +65,7 @@ const ensureArray = value => (isNil(value) ? [] : value);
 
 module.exports = {
   DEFAULT_REGION,
+  DEFAULT_MAX_ATTEMPTS,
   buildClientConfig,
   buildCredentials,
   resolveRegion,

--- a/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
+++ b/packages/serverless-offline-dynamodb-streams/src/dynamodb-streams.js
@@ -1,10 +1,21 @@
 const {Writable} = require('stream');
-const DynamodbClient = require('aws-sdk/clients/dynamodb');
-const DynamodbStreamsClient = require('aws-sdk/clients/dynamodbstreams');
+const {
+  DynamoDBClient,
+  DescribeTableCommand,
+  waitUntilTableExists
+} = require('@aws-sdk/client-dynamodb');
+const {
+  DynamoDBStreamsClient,
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand
+} = require('@aws-sdk/client-dynamodb-streams');
 const DynamodbStreamsReadable = require('dynamodb-streams-readable');
 const {assign, isEmpty, last, get} = require('lodash/fp');
 
 const {normalizeLog} = require('./log');
+const {buildClientConfig} = require('./client-config');
+const {buildCallbackClient} = require('./callback-adapter');
 const DynamodbStreamsEventDefinition = require('./dynamodb-streams-event-definition');
 const DynamodbStreamsEvent = require('./dynamodb-streams-event');
 const {filterRecords} = require('./filter-patterns');
@@ -15,6 +26,16 @@ const {
   loadState,
   saveState
 } = require('./checkpoint-store');
+
+// #248 (aws-sdk v3): the v2 callback methods `dynamodb-streams-readable` calls, mapped to v3 Commands.
+const DDB_STREAMS_READABLE_COMMANDS = {
+  describeStream: DescribeStreamCommand,
+  getShardIterator: GetShardIteratorCommand,
+  getRecords: GetRecordsCommand
+};
+
+// waitUntilTableExists needs a bounded max wait; mirror the v2 waiter's generous polling budget.
+const TABLE_EXISTS_MAX_WAIT_SECONDS = 120;
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -42,8 +63,14 @@ class DynamodbStreams {
     this.options = options;
     this.log = normalizeLog(log);
 
-    this.client = new DynamodbClient(this.options);
-    this.streamsClient = new DynamodbStreamsClient(this.options);
+    this.client = new DynamoDBClient(buildClientConfig(this.options));
+    this.streamsClient = new DynamoDBStreamsClient(buildClientConfig(this.options));
+    // #248 (aws-sdk v3): dynamodb-streams-readable drives the streams client via v2 callback methods;
+    // wrap the v3 client in a promise->callback shim so the readable's pure logic stays untouched.
+    this.readableStreamsClient = buildCallbackClient(
+      this.streamsClient,
+      DDB_STREAMS_READABLE_COMMANDS
+    );
 
     this.readables = [];
 
@@ -81,12 +108,11 @@ class DynamodbStreams {
 
   async _describeTable(tableName) {
     try {
-      await this.client.waitFor('tableExists', {TableName: tableName}).promise();
-      return await this.client
-        .describeTable({
-          TableName: tableName
-        })
-        .promise();
+      await waitUntilTableExists(
+        {client: this.client, maxWaitTime: TABLE_EXISTS_MAX_WAIT_SECONDS},
+        {TableName: tableName}
+      );
+      return await this.client.send(new DescribeTableCommand({TableName: tableName}));
     } catch (err) {
       return this._describeTable(tableName);
     }
@@ -113,11 +139,7 @@ class DynamodbStreams {
 
     const {
       StreamDescription: {Shards: shards}
-    } = await this.streamsClient
-      .describeStream({
-        StreamArn: streamArn
-      })
-      .promise();
+    } = await this.streamsClient.send(new DescribeStreamCommand({StreamArn: streamArn}));
 
     shards.forEach(({ShardId: shardId}) => {
       // #178 (ddb-streams-checkpoint): pick the iterator from any saved checkpoint —
@@ -133,7 +155,7 @@ class DynamodbStreams {
       );
 
       const readable = DynamodbStreamsReadable(
-        this.streamsClient,
+        this.readableStreamsClient,
         streamArn,
         assign(dynamodbStreamsEvent, {
           ...iteratorOptions,

--- a/packages/serverless-offline-dynamodb-streams/test/index.js
+++ b/packages/serverless-offline-dynamodb-streams/test/index.js
@@ -22,8 +22,88 @@ const {
   loadState,
   saveState
 } = require('../src/checkpoint-store');
+const {
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray,
+  DEFAULT_REGION
+} = require('../src/client-config');
+const {toCallbackMethod, buildCallbackClient} = require('../src/callback-adapter');
 
 const LOG_LEVELS = ['debug', 'info', 'notice', 'warning', 'error', 'success'];
+
+// --- buildClientConfig (#248/#252 aws-sdk v3 migration) -------------------
+
+// EARS5: accessKeyId without secretAccessKey must NOT build a half-empty credentials object.
+test('buildCredentials returns undefined when only one key is provided (EARS5)', t => {
+  t.is(buildCredentials({accessKeyId: 'local'}), undefined);
+  t.is(buildCredentials({secretAccessKey: 'local'}), undefined);
+});
+
+test('buildCredentials returns credentials only when BOTH keys are present', t => {
+  t.deepEqual(buildCredentials({accessKeyId: 'a', secretAccessKey: 's'}), {
+    accessKeyId: 'a',
+    secretAccessKey: 's'
+  });
+});
+
+test('buildClientConfig omits credentials when only accessKeyId is set (EARS5)', t => {
+  t.false('credentials' in buildClientConfig({accessKeyId: 'local', endpoint: 'http://x'}));
+});
+
+// EARS4: a custom endpoint without provider.region still works (default region supplied).
+test('buildClientConfig injects a default region for an endpoint with no region (EARS4)', t => {
+  t.is(buildClientConfig({endpoint: 'http://localhost:8000'}).region, DEFAULT_REGION);
+});
+
+test('resolveRegion keeps the provided region untouched', t => {
+  t.is(resolveRegion({endpoint: 'http://x', region: 'eu-west-1'}), 'eu-west-1');
+});
+
+// EARS3: an omitted response array must be treated as [] (no undefined.length crash).
+test('ensureArray returns [] for undefined/null (EARS3)', t => {
+  t.deepEqual(ensureArray(undefined), []);
+  t.deepEqual(ensureArray(null), []);
+});
+
+// --- callback-adapter (#248 promise->callback shim for the readable) -------
+
+class FakeCommand {
+  constructor(params) {
+    this.params = params;
+  }
+}
+
+test('toCallbackMethod forwards a resolved v3 send as (null, data)', async t => {
+  const client = {send: command => Promise.resolve({echoed: command.params})};
+  const method = toCallbackMethod(client, FakeCommand);
+  const data = await new Promise((resolve, reject) => {
+    method({StreamArn: 's'}, (err, d) => (err ? reject(err) : resolve(d)));
+  });
+  t.deepEqual(data, {echoed: {StreamArn: 's'}});
+});
+
+test('toCallbackMethod forwards a rejected v3 send as the err arg (no throw)', async t => {
+  const boom = new Error('boom');
+  const client = {send: () => Promise.reject(boom)};
+  const method = toCallbackMethod(client, FakeCommand);
+  const err = await new Promise(resolve => {
+    method({}, e => resolve(e));
+  });
+  t.is(err, boom);
+});
+
+test('buildCallbackClient exposes a callback method per command plus a passthrough send', t => {
+  const wrapped = buildCallbackClient(
+    {send: () => Promise.resolve('ok')},
+    {getRecords: FakeCommand, describeStream: FakeCommand, getShardIterator: FakeCommand}
+  );
+  t.is(typeof wrapped.getRecords, 'function');
+  t.is(typeof wrapped.describeStream, 'function');
+  t.is(typeof wrapped.getShardIterator, 'function');
+  t.is(typeof wrapped.send, 'function');
+});
 
 // --- normalizeLog --------------------------------------------------------
 

--- a/packages/serverless-offline-dynamodb-streams/test/index.js
+++ b/packages/serverless-offline-dynamodb-streams/test/index.js
@@ -654,11 +654,12 @@ const buildStreamsHarness = () => {
     {}
   );
 
-  // Stub the AWS edges so `_dynamodbStreamsEvent` resolves a single shard.
+  // Stub the AWS edges so `_dynamodbStreamsEvent` resolves a single shard. #248 (aws-sdk v3): the
+  // production client is driven via `send(new DescribeStreamCommand(...))`, so stub `send` (which
+  // returns the response directly) rather than the v2 `describeStream().promise()` method.
   streams._describeTable = () => Promise.resolve({Table: {LatestStreamArn: HARNESS_STREAM_ARN}});
-  streams.streamsClient.describeStream = () => ({
-    promise: () => Promise.resolve({StreamDescription: {Shards: [{ShardId: SHARD_ID}]}})
-  });
+  streams.streamsClient.send = () =>
+    Promise.resolve({StreamDescription: {Shards: [{ShardId: SHARD_ID}]}});
 
   return {streams, file, handlerCalls};
 };

--- a/packages/serverless-offline-eventbridge/package.json
+++ b/packages/serverless-offline-eventbridge/package.json
@@ -14,6 +14,7 @@
   "files": [
     "src/index.js",
     "src/log.js",
+    "src/client-config.js",
     "src/eventbridge.js",
     "src/eventbridge-event.js",
     "src/eventbridge-event-definition.js",
@@ -28,7 +29,7 @@
     "serverless-offline": ">=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-sqs": "^3.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/serverless-offline-eventbridge/src/client-config.js
+++ b/packages/serverless-offline-eventbridge/src/client-config.js
@@ -1,0 +1,58 @@
+const {isNil, omit} = require('lodash/fp');
+
+// #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
+// defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
+// options into a clean v3 client config so the offline plugins keep working against local emulators.
+
+// A region the v3 client accepts when none was provided. Local emulators (ElasticMQ, sqslite,
+// DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
+const DEFAULT_REGION = 'us-east-1';
+
+// #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
+// `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
+// "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
+// neither) key is supplied we omit `credentials` entirely and let the v3 default provider chain run.
+const buildCredentials = options => {
+  const accessKeyId = options ? options.accessKeyId : undefined;
+  const secretAccessKey = options ? options.secretAccessKey : undefined;
+  if (isNil(accessKeyId) || isNil(secretAccessKey)) return undefined;
+  const sessionToken = options ? options.sessionToken : undefined;
+  return {...(isNil(sessionToken) ? {} : {sessionToken}), accessKeyId, secretAccessKey};
+};
+
+// #248 (aws-sdk v3): a custom `endpoint` without `provider.region` must still work. v2 fell back to a
+// default region; v3 throws "Region is missing". When an endpoint is set and no region is supplied,
+// inject a default so signing succeeds against the local emulator.
+const resolveRegion = options => {
+  const region = options ? options.region : undefined;
+  if (!isNil(region)) return region;
+  return options && options.endpoint ? DEFAULT_REGION : undefined;
+};
+
+// buildClientConfig(options) -> a v3-ready client config. Pure + non-mutating: never sends a
+// half-empty credentials object, and never leaves the region undefined when an endpoint is set.
+// The original `accessKeyId`/`secretAccessKey`/`sessionToken` scalars are dropped (v3 reads them
+// from `credentials`); every other option (endpoint, maxAttempts, ...) is passed through untouched.
+const buildClientConfig = (options = {}) => {
+  const base = omit(['accessKeyId', 'secretAccessKey', 'sessionToken', 'region'], options);
+  const credentials = buildCredentials(options);
+  const region = resolveRegion(options);
+  return {
+    ...base,
+    ...(isNil(region) ? {} : {region}),
+    ...(isNil(credentials) ? {} : {credentials})
+  };
+};
+
+// #248 (aws-sdk v3): a v3 GetRecords/ReceiveMessage response OMITS the array key entirely when empty
+// (v2 always returned `[]`). Guard so `response.Records.length` / `.Messages.length` never throws on
+// `undefined`. Pure: returns the array unchanged when present, `[]` when nil.
+const ensureArray = value => (isNil(value) ? [] : value);
+
+module.exports = {
+  DEFAULT_REGION,
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray
+};

--- a/packages/serverless-offline-eventbridge/src/client-config.js
+++ b/packages/serverless-offline-eventbridge/src/client-config.js
@@ -8,6 +8,13 @@ const {isNil, omit} = require('lodash/fp');
 // DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
 const DEFAULT_REGION = 'us-east-1';
 
+// #248 (aws-sdk v3): v3 clients default to maxAttempts:3 with ~150ms total backoff and give up
+// (ECONNRESET "socket hang up") before a freshly-started local emulator (ElasticMQ) finishes
+// booting — aws-sdk v2 tolerated this. A generous default lets the offline plugin ride out the
+// emulator's cold start. A user-supplied `maxAttempts` still wins (it survives in `base` and is
+// spread after this default below).
+const DEFAULT_MAX_ATTEMPTS = 20;
+
 // #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
 // `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
 // "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
@@ -40,7 +47,9 @@ const buildClientConfig = (options = {}) => {
   return {
     ...base,
     ...(isNil(region) ? {} : {region}),
-    ...(isNil(credentials) ? {} : {credentials})
+    ...(isNil(credentials) ? {} : {credentials}),
+    // Cold-start default; a user-supplied `maxAttempts` (kept in `base`) still wins.
+    maxAttempts: isNil(base.maxAttempts) ? DEFAULT_MAX_ATTEMPTS : base.maxAttempts
   };
 };
 
@@ -51,6 +60,7 @@ const ensureArray = value => (isNil(value) ? [] : value);
 
 module.exports = {
   DEFAULT_REGION,
+  DEFAULT_MAX_ATTEMPTS,
   buildClientConfig,
   buildCredentials,
   resolveRegion,

--- a/packages/serverless-offline-eventbridge/src/eventbridge.js
+++ b/packages/serverless-offline-eventbridge/src/eventbridge.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const {randomUUID} = require('crypto');
-const SQSClient = require('aws-sdk/clients/sqs');
+const {SQSClient, GetQueueUrlCommand, SendMessageCommand} = require('@aws-sdk/client-sqs');
 
 const {
   castArray,
@@ -15,6 +15,7 @@ const {
 } = require('lodash/fp');
 
 const {normalizeLog} = require('./log');
+const {buildClientConfig} = require('./client-config');
 const EventBridgeEventDefinition = require('./eventbridge-event-definition');
 const EventBridgeEvent = require('./eventbridge-event');
 const {buildEventBridgeEvent} = require('./eventbridge-event');
@@ -395,18 +396,18 @@ class EventBridge {
     if (isNil(arn)) return;
 
     try {
-      if (!this.sqsClient) this.sqsClient = new SQSClient(this.options);
+      if (!this.sqsClient) this.sqsClient = new SQSClient(buildClientConfig(this.options));
       const queueName = String(arn).split(':').pop();
-      const {QueueUrl} = await this.sqsClient.getQueueUrl({QueueName: queueName}).promise();
-      await this.sqsClient
-        .sendMessage({
+      const {QueueUrl} = await this.sqsClient.send(new GetQueueUrlCommand({QueueName: queueName}));
+      await this.sqsClient.send(
+        new SendMessageCommand({
           QueueUrl,
           MessageBody: JSON.stringify({
             requestPayload: event,
             responsePayload: {errorMessage: err.message, errorType: err.name}
           })
         })
-        .promise();
+      );
     } catch (dlqErr) {
       this.log.warning(dlqErr.stack);
     }

--- a/packages/serverless-offline-eventbridge/test/index.js
+++ b/packages/serverless-offline-eventbridge/test/index.js
@@ -13,6 +13,49 @@ const {
 } = require('../src/eventbridge');
 const EventBridgeEvent = require('../src/eventbridge-event');
 const EventBridgeEventDefinition = require('../src/eventbridge-event-definition');
+const {
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray,
+  DEFAULT_REGION
+} = require('../src/client-config');
+
+// ---------------------------------------------------------------------------
+// buildClientConfig (#248/#252 aws-sdk v3 migration)
+// ---------------------------------------------------------------------------
+
+// EARS5: accessKeyId without secretAccessKey must NOT build a half-empty credentials object.
+test('buildCredentials returns undefined when only one key is provided (EARS5)', t => {
+  t.is(buildCredentials({accessKeyId: 'local'}), undefined);
+  t.is(buildCredentials({secretAccessKey: 'local'}), undefined);
+});
+
+test('buildCredentials returns credentials only when BOTH keys are present', t => {
+  t.deepEqual(buildCredentials({accessKeyId: 'a', secretAccessKey: 's'}), {
+    accessKeyId: 'a',
+    secretAccessKey: 's'
+  });
+});
+
+test('buildClientConfig omits credentials when only accessKeyId is set (EARS5)', t => {
+  t.false('credentials' in buildClientConfig({accessKeyId: 'local', endpoint: 'http://x'}));
+});
+
+// EARS4: a custom endpoint without provider.region still works (default region supplied).
+test('buildClientConfig injects a default region for an endpoint with no region (EARS4)', t => {
+  t.is(buildClientConfig({endpoint: 'http://localhost:9324'}).region, DEFAULT_REGION);
+});
+
+test('resolveRegion keeps the provided region untouched', t => {
+  t.is(resolveRegion({endpoint: 'http://x', region: 'eu-west-1'}), 'eu-west-1');
+});
+
+// EARS3: an omitted response array must be treated as [] (no undefined.length crash).
+test('ensureArray returns [] for undefined/null (EARS3)', t => {
+  t.deepEqual(ensureArray(undefined), []);
+  t.deepEqual(ensureArray(null), []);
+});
 
 // ---------------------------------------------------------------------------
 // Group A — normalizeLog (SQS-identical)

--- a/packages/serverless-offline-kinesis/package.json
+++ b/packages/serverless-offline-kinesis/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-kinesis": "^3.0.0",
+    "@smithy/node-http-handler": "^4.0.0",
     "kinesis-readable": "^1.2.0",
     "lodash": "^4.17.21"
   },

--- a/packages/serverless-offline-kinesis/package.json
+++ b/packages/serverless-offline-kinesis/package.json
@@ -14,6 +14,8 @@
   "files": [
     "src/index.js",
     "src/log.js",
+    "src/client-config.js",
+    "src/callback-adapter.js",
     "src/kinesis.js",
     "src/kinesis-event.js",
     "src/kinesis-event-definition.js"
@@ -31,7 +33,7 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-kinesis": "^3.0.0",
     "kinesis-readable": "^1.2.0",
     "lodash": "^4.17.21"
   },

--- a/packages/serverless-offline-kinesis/src/callback-adapter.js
+++ b/packages/serverless-offline-kinesis/src/callback-adapter.js
@@ -1,0 +1,32 @@
+// #248 (aws-sdk v3): `kinesis-readable` drives the AWS client through the aws-sdk v2 CALLBACK
+// contract — `client.describeStream(params, cb)`, `client.getShardIterator(params, cb)`,
+// `client.getRecords(params, cb)`. The @aws-sdk v3 client only exposes the promise-based
+// `client.send(new Command(params))`. Rather than fork the readable, wrap the v3 client in a thin
+// promise->callback shim that re-exposes exactly the v2 callback-style methods the readable expects,
+// leaving the readable's pure logic untouched.
+
+// toCallbackMethod(client, Command) -> (params, callback) => Promise
+// Pure factory: returns a node-style callback function that sends the v3 command and forwards
+// (err, data) to the callback. Never throws synchronously; a rejected send surfaces as the `err` arg.
+// The send promise is returned (rejection handled in-chain) so it is never floated, and the callback
+// runs exactly once on settlement — mirroring the aws-sdk v2 callback contract kinesis-readable uses.
+const toCallbackMethod = (client, Command) => (params, callback) =>
+  client.send(new Command(params)).then(
+    data => callback(null, data),
+    err => callback(err)
+  );
+
+// buildCallbackClient(client, commandsByMethod) -> {<method>: (params, cb) => void, send}
+// Pure: maps every {methodName: Command} entry to a v2-style callback method bound to `client`, and
+// keeps `send` available for direct v3 use. Does not mutate `client`.
+const buildCallbackClient = (client, commandsByMethod) => {
+  const methods = Object.fromEntries(
+    Object.entries(commandsByMethod).map(([method, Command]) => [
+      method,
+      toCallbackMethod(client, Command)
+    ])
+  );
+  return {...methods, send: (...args) => client.send(...args)};
+};
+
+module.exports = {toCallbackMethod, buildCallbackClient};

--- a/packages/serverless-offline-kinesis/src/callback-adapter.js
+++ b/packages/serverless-offline-kinesis/src/callback-adapter.js
@@ -1,3 +1,5 @@
+const {identity, getOr, isNil} = require('lodash/fp');
+
 // #248 (aws-sdk v3): `kinesis-readable` drives the AWS client through the aws-sdk v2 CALLBACK
 // contract — `client.describeStream(params, cb)`, `client.getShardIterator(params, cb)`,
 // `client.getRecords(params, cb)`. The @aws-sdk v3 client only exposes the promise-based
@@ -5,28 +7,50 @@
 // promise->callback shim that re-exposes exactly the v2 callback-style methods the readable expects,
 // leaving the readable's pure logic untouched.
 
-// toCallbackMethod(client, Command) -> (params, callback) => Promise
-// Pure factory: returns a node-style callback function that sends the v3 command and forwards
-// (err, data) to the callback. Never throws synchronously; a rejected send surfaces as the `err` arg.
-// The send promise is returned (rejection handled in-chain) so it is never floated, and the callback
-// runs exactly once on settlement — mirroring the aws-sdk v2 callback contract kinesis-readable uses.
-const toCallbackMethod = (client, Command) => (params, callback) =>
-  client.send(new Command(params)).then(
-    data => callback(null, data),
-    err => callback(err)
-  );
+// #248 (aws-sdk v3) — EARS3 parity: a v3 GetRecords response OMITS `Records` entirely when the batch
+// is empty (aws-sdk v2 always returned `[]`). `kinesis-readable`'s `read()` reads `data.Records.length`
+// UNGUARDED, so an omitted `Records` would throw `Cannot read properties of undefined (reading
+// 'length')`. Mirror the dynamodb-streams-readable guard at this same I/O seam: normalize the
+// getRecords response so `Records` defaults to `[]` before it ever reaches kinesis-readable.
+// Pure + non-mutating: returns a new object, never the input. Coalesces both an OMITTED key (the real
+// v3 empty-batch shape) and an explicit `null` to `[]` — the same `isNil` parity as `ensureArray`.
+const ensureRecordsResponse = response => {
+  const records = getOr(undefined, 'Records', response);
+  return {...response, Records: isNil(records) ? [] : records};
+};
+
+// toCallbackMethod(client, Command, [normalize]) -> (params, callback) => Promise
+// Pure factory: returns a node-style callback function that sends the v3 command, runs the resolved
+// data through `normalize` (identity by default), and forwards (err, data) to the callback. Never
+// throws synchronously; a rejected send surfaces as the `err` arg. The send promise is returned
+// (rejection handled in-chain) so it is never floated, and the callback runs exactly once on
+// settlement — mirroring the aws-sdk v2 callback contract kinesis-readable uses.
+const toCallbackMethod =
+  (client, Command, normalize = identity) =>
+  (params, callback) =>
+    client.send(new Command(params)).then(
+      data => callback(null, normalize(data)),
+      err => callback(err)
+    );
+
+// #248 (aws-sdk v3): per-method response normalizers. Only getRecords needs the `Records -> []` guard;
+// every other method passes through unchanged (identity).
+const RESPONSE_NORMALIZERS = {
+  getRecords: ensureRecordsResponse
+};
 
 // buildCallbackClient(client, commandsByMethod) -> {<method>: (params, cb) => void, send}
-// Pure: maps every {methodName: Command} entry to a v2-style callback method bound to `client`, and
-// keeps `send` available for direct v3 use. Does not mutate `client`.
+// Pure: maps every {methodName: Command} entry to a v2-style callback method bound to `client`,
+// applying the method's response normalizer (default identity), and keeps `send` available for direct
+// v3 use. Does not mutate `client`.
 const buildCallbackClient = (client, commandsByMethod) => {
   const methods = Object.fromEntries(
     Object.entries(commandsByMethod).map(([method, Command]) => [
       method,
-      toCallbackMethod(client, Command)
+      toCallbackMethod(client, Command, getOr(identity, method, RESPONSE_NORMALIZERS))
     ])
   );
   return {...methods, send: (...args) => client.send(...args)};
 };
 
-module.exports = {toCallbackMethod, buildCallbackClient};
+module.exports = {toCallbackMethod, buildCallbackClient, ensureRecordsResponse};

--- a/packages/serverless-offline-kinesis/src/client-config.js
+++ b/packages/serverless-offline-kinesis/src/client-config.js
@@ -1,0 +1,58 @@
+const {isNil, omit} = require('lodash/fp');
+
+// #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
+// defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
+// options into a clean v3 client config so the offline plugins keep working against local emulators.
+
+// A region the v3 client accepts when none was provided. Local emulators (ElasticMQ, sqslite,
+// DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
+const DEFAULT_REGION = 'us-east-1';
+
+// #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
+// `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
+// "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
+// neither) key is supplied we omit `credentials` entirely and let the v3 default provider chain run.
+const buildCredentials = options => {
+  const accessKeyId = options ? options.accessKeyId : undefined;
+  const secretAccessKey = options ? options.secretAccessKey : undefined;
+  if (isNil(accessKeyId) || isNil(secretAccessKey)) return undefined;
+  const sessionToken = options ? options.sessionToken : undefined;
+  return {...(isNil(sessionToken) ? {} : {sessionToken}), accessKeyId, secretAccessKey};
+};
+
+// #248 (aws-sdk v3): a custom `endpoint` without `provider.region` must still work. v2 fell back to a
+// default region; v3 throws "Region is missing". When an endpoint is set and no region is supplied,
+// inject a default so signing succeeds against the local emulator.
+const resolveRegion = options => {
+  const region = options ? options.region : undefined;
+  if (!isNil(region)) return region;
+  return options && options.endpoint ? DEFAULT_REGION : undefined;
+};
+
+// buildClientConfig(options) -> a v3-ready client config. Pure + non-mutating: never sends a
+// half-empty credentials object, and never leaves the region undefined when an endpoint is set.
+// The original `accessKeyId`/`secretAccessKey`/`sessionToken` scalars are dropped (v3 reads them
+// from `credentials`); every other option (endpoint, maxAttempts, ...) is passed through untouched.
+const buildClientConfig = (options = {}) => {
+  const base = omit(['accessKeyId', 'secretAccessKey', 'sessionToken', 'region'], options);
+  const credentials = buildCredentials(options);
+  const region = resolveRegion(options);
+  return {
+    ...base,
+    ...(isNil(region) ? {} : {region}),
+    ...(isNil(credentials) ? {} : {credentials})
+  };
+};
+
+// #248 (aws-sdk v3): a v3 GetRecords/ReceiveMessage response OMITS the array key entirely when empty
+// (v2 always returned `[]`). Guard so `response.Records.length` / `.Messages.length` never throws on
+// `undefined`. Pure: returns the array unchanged when present, `[]` when nil.
+const ensureArray = value => (isNil(value) ? [] : value);
+
+module.exports = {
+  DEFAULT_REGION,
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray
+};

--- a/packages/serverless-offline-kinesis/src/client-config.js
+++ b/packages/serverless-offline-kinesis/src/client-config.js
@@ -1,8 +1,17 @@
 const {isNil, omit} = require('lodash/fp');
+const {NodeHttpHandler} = require('@smithy/node-http-handler');
 
 // #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
 // defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
 // options into a clean v3 client config so the offline plugins keep working against local emulators.
+
+// #248 (aws-sdk v3): unlike the other clients, `@aws-sdk/client-kinesis` defaults its request handler
+// to `NodeHttp2Handler` (real AWS Kinesis serves HTTP/2). The local emulator (kinesalite) only speaks
+// HTTP/1.1, so the default handler fails the connection with `ERR_HTTP2_ERROR: Protocol error` and the
+// plugin hangs forever in `_describeStream`. Force the HTTP/1.1 handler so the offline client reaches
+// kinesalite — `@smithy/node-http-handler` is a direct dependency of `@aws-sdk/client-kinesis`, so it
+// is always installed alongside it.
+const buildRequestHandler = () => new NodeHttpHandler();
 
 // A region the v3 client accepts when none was provided. Local emulators (ElasticMQ, sqslite,
 // DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
@@ -40,7 +49,10 @@ const buildClientConfig = (options = {}) => {
   return {
     ...base,
     ...(isNil(region) ? {} : {region}),
-    ...(isNil(credentials) ? {} : {credentials})
+    ...(isNil(credentials) ? {} : {credentials}),
+    // Force HTTP/1.1 so the client can reach kinesalite (see buildRequestHandler above). A
+    // user-supplied `requestHandler` in `options` still wins (it lands in `base` and is spread first).
+    requestHandler: base.requestHandler || buildRequestHandler()
   };
 };
 

--- a/packages/serverless-offline-kinesis/src/client-config.js
+++ b/packages/serverless-offline-kinesis/src/client-config.js
@@ -17,6 +17,13 @@ const buildRequestHandler = () => new NodeHttpHandler();
 // DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
 const DEFAULT_REGION = 'us-east-1';
 
+// #248 (aws-sdk v3): v3 clients default to maxAttempts:3 with ~150ms total backoff and give up
+// (ECONNRESET "socket hang up") before a freshly-started local emulator (kinesalite) finishes
+// booting — aws-sdk v2 tolerated this. A generous default lets the offline plugin ride out the
+// emulator's cold start. A user-supplied `maxAttempts` still wins (it survives in `base` and is
+// spread after this default below).
+const DEFAULT_MAX_ATTEMPTS = 20;
+
 // #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
 // `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
 // "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
@@ -50,6 +57,8 @@ const buildClientConfig = (options = {}) => {
     ...base,
     ...(isNil(region) ? {} : {region}),
     ...(isNil(credentials) ? {} : {credentials}),
+    // Cold-start default; a user-supplied `maxAttempts` (kept in `base`) still wins.
+    maxAttempts: isNil(base.maxAttempts) ? DEFAULT_MAX_ATTEMPTS : base.maxAttempts,
     // Force HTTP/1.1 so the client can reach kinesalite (see buildRequestHandler above). A
     // user-supplied `requestHandler` in `options` still wins (it lands in `base` and is spread first).
     requestHandler: base.requestHandler || buildRequestHandler()
@@ -63,6 +72,7 @@ const ensureArray = value => (isNil(value) ? [] : value);
 
 module.exports = {
   DEFAULT_REGION,
+  DEFAULT_MAX_ATTEMPTS,
   buildClientConfig,
   buildCredentials,
   resolveRegion,

--- a/packages/serverless-offline-kinesis/src/kinesis.js
+++ b/packages/serverless-offline-kinesis/src/kinesis.js
@@ -1,11 +1,29 @@
 const {Writable} = require('stream');
-const KinesisClient = require('aws-sdk/clients/kinesis');
+const {
+  KinesisClient,
+  DescribeStreamCommand,
+  GetRecordsCommand,
+  GetShardIteratorCommand,
+  waitUntilStreamExists
+} = require('@aws-sdk/client-kinesis');
 const KinesisReadable = require('kinesis-readable');
 const {assign} = require('lodash/fp');
 
 const {normalizeLog} = require('./log');
+const {buildClientConfig} = require('./client-config');
+const {buildCallbackClient} = require('./callback-adapter');
 const KinesisEventDefinition = require('./kinesis-event-definition');
 const KinesisEvent = require('./kinesis-event');
+
+// #248 (aws-sdk v3): the v2 callback methods `kinesis-readable` calls, mapped to their v3 Commands.
+const KINESIS_READABLE_COMMANDS = {
+  describeStream: DescribeStreamCommand,
+  getShardIterator: GetShardIteratorCommand,
+  getRecords: GetRecordsCommand
+};
+
+// waitUntilStreamExists needs a bounded max wait; mirror the v2 waiter's generous polling budget.
+const STREAM_EXISTS_MAX_WAIT_SECONDS = 120;
 
 const delay = timeout =>
   new Promise(resolve => {
@@ -25,7 +43,10 @@ class Kinesis {
     this.lambda = lambda;
     this.options = options;
     this.log = normalizeLog(log);
-    this.client = new KinesisClient(this.options);
+    this.client = new KinesisClient(buildClientConfig(this.options));
+    // #248 (aws-sdk v3): kinesis-readable drives the client via v2 callback methods; wrap the v3
+    // client in a promise->callback shim so the readable's pure logic is untouched.
+    this.readableClient = buildCallbackClient(this.client, KINESIS_READABLE_COMMANDS);
 
     this.readables = [];
   }
@@ -54,12 +75,11 @@ class Kinesis {
 
   async _describeStream(streamName) {
     try {
-      await this.client.waitFor('streamExists', {StreamName: streamName}).promise();
-      return await this.client
-        .describeStream({
-          StreamName: streamName
-        })
-        .promise();
+      await waitUntilStreamExists(
+        {client: this.client, maxWaitTime: STREAM_EXISTS_MAX_WAIT_SECONDS},
+        {StreamName: streamName}
+      );
+      return await this.client.send(new DescribeStreamCommand({StreamName: streamName}));
     } catch (err) {
       return this._describeStream(streamName);
     }
@@ -77,7 +97,7 @@ class Kinesis {
 
     shards.forEach(({ShardId: shardId}) => {
       const readable = KinesisReadable(
-        this.client,
+        this.readableClient,
         streamName,
         assign(kinesisEvent, {
           shardId,

--- a/packages/serverless-offline-kinesis/test/index.js
+++ b/packages/serverless-offline-kinesis/test/index.js
@@ -49,6 +49,19 @@ test('resolveRegion keeps the provided region untouched', t => {
   t.is(resolveRegion({endpoint: 'http://x', region: 'eu-west-1'}), 'eu-west-1');
 });
 
+// #248: kinesis (unlike the other clients) defaults to NodeHttp2Handler; kinesalite only speaks
+// HTTP/1.1. buildClientConfig must force an HTTP/1.1 request handler so the offline client connects
+// (otherwise the plugin hangs on ERR_HTTP2_ERROR in _describeStream).
+test('buildClientConfig forces an HTTP/1.1 request handler for kinesalite', t => {
+  const {requestHandler} = buildClientConfig({endpoint: 'http://localhost:4567'});
+  t.is(requestHandler.constructor.name, 'NodeHttpHandler');
+});
+
+test('buildClientConfig keeps a user-supplied requestHandler', t => {
+  const custom = {marker: 'mine'};
+  t.is(buildClientConfig({requestHandler: custom}).requestHandler, custom);
+});
+
 // EARS3: an omitted response array must be treated as [] (no undefined.length crash).
 test('ensureArray returns [] for undefined/null (EARS3)', t => {
   t.deepEqual(ensureArray(undefined), []);

--- a/packages/serverless-offline-kinesis/test/index.js
+++ b/packages/serverless-offline-kinesis/test/index.js
@@ -13,7 +13,11 @@ const {
   ensureArray,
   DEFAULT_REGION
 } = require('../src/client-config');
-const {toCallbackMethod, buildCallbackClient} = require('../src/callback-adapter');
+const {
+  toCallbackMethod,
+  buildCallbackClient,
+  ensureRecordsResponse
+} = require('../src/callback-adapter');
 
 // ---------------------------------------------------------------------------
 // buildClientConfig (#248/#252 aws-sdk v3 migration)
@@ -89,6 +93,68 @@ test('buildCallbackClient exposes a callback method per command plus a passthrou
   t.is(typeof wrapped.getRecords, 'function');
   t.is(typeof wrapped.describeStream, 'function');
   t.is(typeof wrapped.send, 'function');
+});
+
+// ---------------------------------------------------------------------------
+// EARS3 parity: kinesis-readable reads `data.Records.length` UNGUARDED, but a v3
+// GetRecords response OMITS `Records` when the batch is empty. The callback adapter
+// must default `Records` to [] before the data reaches kinesis-readable (mirrors the
+// dynamodb-streams-readable guard).
+// ---------------------------------------------------------------------------
+
+test('ensureRecordsResponse defaults an omitted Records to [] (EARS3)', t => {
+  // The exact shape v3 GetRecords returns on an empty poll: no `Records` key at all.
+  const v3EmptyResponse = {NextShardIterator: 'AAAA', MillisBehindLatest: 0};
+  const normalized = ensureRecordsResponse(v3EmptyResponse);
+  t.deepEqual(normalized.Records, []);
+  // pinning the exact bug: `.length` must be readable (this is what kinesis-readable does)
+  t.is(normalized.Records.length, 0);
+  // other fields are preserved, input is not mutated
+  t.is(normalized.NextShardIterator, 'AAAA');
+  t.false('Records' in v3EmptyResponse);
+});
+
+test('ensureRecordsResponse also coalesces an explicit null Records to []', t => {
+  const normalized = ensureRecordsResponse({Records: null, NextShardIterator: 'BBBB'});
+  t.deepEqual(normalized.Records, []);
+  t.is(normalized.Records.length, 0);
+});
+
+test('ensureRecordsResponse leaves a populated Records array untouched', t => {
+  const records = [{SequenceNumber: '1'}, {SequenceNumber: '2'}];
+  const normalized = ensureRecordsResponse({Records: records, NextShardIterator: 'CCCC'});
+  t.deepEqual(normalized.Records, records);
+  t.is(normalized.NextShardIterator, 'CCCC');
+});
+
+test('buildCallbackClient guards getRecords so an omitted Records reaches the cb as [] (EARS3)', async t => {
+  // The v3 client resolves a GetRecords response with NO `Records` key.
+  const client = {send: () => Promise.resolve({NextShardIterator: 'next'})};
+  const wrapped = buildCallbackClient(client, {getRecords: FakeCommand});
+
+  const data = await new Promise((resolve, reject) => {
+    wrapped.getRecords({ShardIterator: 'it', Limit: 10}, (err, d) =>
+      err ? reject(err) : resolve(d)
+    );
+  });
+
+  // This is exactly what kinesis-readable does next — it must not throw on undefined.
+  t.notThrows(() => data.Records.length);
+  t.deepEqual(data.Records, []);
+  t.is(data.NextShardIterator, 'next');
+});
+
+test('buildCallbackClient does NOT inject Records into non-getRecords methods', async t => {
+  // describeStream/getShardIterator responses must pass through untouched (identity normalizer).
+  const client = {send: () => Promise.resolve({ShardIterator: 'shard-it'})};
+  const wrapped = buildCallbackClient(client, {getShardIterator: FakeCommand});
+
+  const data = await new Promise((resolve, reject) => {
+    wrapped.getShardIterator({}, (err, d) => (err ? reject(err) : resolve(d)));
+  });
+
+  t.is(data.ShardIterator, 'shard-it');
+  t.false('Records' in data);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/serverless-offline-kinesis/test/index.js
+++ b/packages/serverless-offline-kinesis/test/index.js
@@ -6,6 +6,90 @@ const {defaultLog, normalizeLog} = require('../src/log');
 const {shouldRetry} = require('../src/kinesis');
 const KinesisEvent = require('../src/kinesis-event');
 const KinesisEventDefinition = require('../src/kinesis-event-definition');
+const {
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray,
+  DEFAULT_REGION
+} = require('../src/client-config');
+const {toCallbackMethod, buildCallbackClient} = require('../src/callback-adapter');
+
+// ---------------------------------------------------------------------------
+// buildClientConfig (#248/#252 aws-sdk v3 migration)
+// ---------------------------------------------------------------------------
+
+// EARS5: accessKeyId without secretAccessKey must NOT build a half-empty credentials object.
+test('buildCredentials returns undefined when only one key is provided (EARS5)', t => {
+  t.is(buildCredentials({accessKeyId: 'local'}), undefined);
+  t.is(buildCredentials({secretAccessKey: 'local'}), undefined);
+});
+
+test('buildCredentials returns credentials only when BOTH keys are present', t => {
+  t.deepEqual(buildCredentials({accessKeyId: 'a', secretAccessKey: 's'}), {
+    accessKeyId: 'a',
+    secretAccessKey: 's'
+  });
+});
+
+test('buildClientConfig omits credentials when only accessKeyId is set (EARS5)', t => {
+  t.false('credentials' in buildClientConfig({accessKeyId: 'local', endpoint: 'http://x'}));
+});
+
+// EARS4: a custom endpoint without provider.region still works (default region supplied).
+test('buildClientConfig injects a default region for an endpoint with no region (EARS4)', t => {
+  t.is(buildClientConfig({endpoint: 'http://localhost:4567'}).region, DEFAULT_REGION);
+});
+
+test('resolveRegion keeps the provided region untouched', t => {
+  t.is(resolveRegion({endpoint: 'http://x', region: 'eu-west-1'}), 'eu-west-1');
+});
+
+// EARS3: an omitted response array must be treated as [] (no undefined.length crash).
+test('ensureArray returns [] for undefined/null (EARS3)', t => {
+  t.deepEqual(ensureArray(undefined), []);
+  t.deepEqual(ensureArray(null), []);
+});
+
+// ---------------------------------------------------------------------------
+// callback-adapter (#248 promise->callback shim for kinesis-readable)
+// ---------------------------------------------------------------------------
+
+class FakeCommand {
+  constructor(params) {
+    this.params = params;
+  }
+}
+
+test('toCallbackMethod forwards a resolved v3 send as (null, data)', async t => {
+  const client = {send: command => Promise.resolve({echoed: command.params})};
+  const method = toCallbackMethod(client, FakeCommand);
+  const data = await new Promise((resolve, reject) => {
+    method({StreamName: 's'}, (err, d) => (err ? reject(err) : resolve(d)));
+  });
+  t.deepEqual(data, {echoed: {StreamName: 's'}});
+});
+
+test('toCallbackMethod forwards a rejected v3 send as the err arg (no throw)', async t => {
+  const boom = new Error('boom');
+  const client = {send: () => Promise.reject(boom)};
+  const method = toCallbackMethod(client, FakeCommand);
+  const err = await new Promise(resolve => {
+    method({}, e => resolve(e));
+  });
+  t.is(err, boom);
+});
+
+test('buildCallbackClient exposes a callback method per command plus a passthrough send', t => {
+  const client = {send: () => Promise.resolve('ok')};
+  const wrapped = buildCallbackClient(client, {
+    getRecords: FakeCommand,
+    describeStream: FakeCommand
+  });
+  t.is(typeof wrapped.getRecords, 'function');
+  t.is(typeof wrapped.describeStream, 'function');
+  t.is(typeof wrapped.send, 'function');
+});
 
 // ---------------------------------------------------------------------------
 // normalizeLog (v4 logger shim)

--- a/packages/serverless-offline-s3/package.json
+++ b/packages/serverless-offline-s3/package.json
@@ -30,7 +30,6 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
     "figures": "^5.0.0",
     "lodash": "^4.17.21",
     "minio": "^8.0.7"

--- a/packages/serverless-offline-sqs/package.json
+++ b/packages/serverless-offline-sqs/package.json
@@ -14,6 +14,7 @@
   "files": [
     "src/index.js",
     "src/log.js",
+    "src/client-config.js",
     "src/sqs.js",
     "src/sqs-event.js",
     "src/sqs-event-definition.js"
@@ -31,7 +32,7 @@
     "serverless-offline": "^10.0.2 || >=11"
   },
   "dependencies": {
-    "aws-sdk": "^2.1234.0",
+    "@aws-sdk/client-sqs": "^3.0.0",
     "lodash": "^4.17.21",
     "p-queue": "^6.6.2"
   },

--- a/packages/serverless-offline-sqs/src/client-config.js
+++ b/packages/serverless-offline-sqs/src/client-config.js
@@ -1,0 +1,58 @@
+const {isNil, omit} = require('lodash/fp');
+
+// #248/#252 (aws-sdk v3): the v2 client silently ignored an empty/partial `credentials` object and
+// defaulted the region; the v3 client does not. These pure helpers normalize the Serverless-supplied
+// options into a clean v3 client config so the offline plugins keep working against local emulators.
+
+// A region the v3 client accepts when none was provided. Local emulators (ElasticMQ, sqslite,
+// DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
+const DEFAULT_REGION = 'us-east-1';
+
+// #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
+// `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
+// "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
+// neither) key is supplied we omit `credentials` entirely and let the v3 default provider chain run.
+const buildCredentials = options => {
+  const accessKeyId = options ? options.accessKeyId : undefined;
+  const secretAccessKey = options ? options.secretAccessKey : undefined;
+  if (isNil(accessKeyId) || isNil(secretAccessKey)) return undefined;
+  const sessionToken = options ? options.sessionToken : undefined;
+  return {...(isNil(sessionToken) ? {} : {sessionToken}), accessKeyId, secretAccessKey};
+};
+
+// #248 (aws-sdk v3): a custom `endpoint` without `provider.region` must still work. v2 fell back to a
+// default region; v3 throws "Region is missing". When an endpoint is set and no region is supplied,
+// inject a default so signing succeeds against the local emulator.
+const resolveRegion = options => {
+  const region = options ? options.region : undefined;
+  if (!isNil(region)) return region;
+  return options && options.endpoint ? DEFAULT_REGION : undefined;
+};
+
+// buildClientConfig(options) -> a v3-ready client config. Pure + non-mutating: never sends a
+// half-empty credentials object, and never leaves the region undefined when an endpoint is set.
+// The original `accessKeyId`/`secretAccessKey`/`sessionToken` scalars are dropped (v3 reads them
+// from `credentials`); every other option (endpoint, maxAttempts, ...) is passed through untouched.
+const buildClientConfig = (options = {}) => {
+  const base = omit(['accessKeyId', 'secretAccessKey', 'sessionToken', 'region'], options);
+  const credentials = buildCredentials(options);
+  const region = resolveRegion(options);
+  return {
+    ...base,
+    ...(isNil(region) ? {} : {region}),
+    ...(isNil(credentials) ? {} : {credentials})
+  };
+};
+
+// #248 (aws-sdk v3): a v3 GetRecords/ReceiveMessage response OMITS the array key entirely when empty
+// (v2 always returned `[]`). Guard so `response.Records.length` / `.Messages.length` never throws on
+// `undefined`. Pure: returns the array unchanged when present, `[]` when nil.
+const ensureArray = value => (isNil(value) ? [] : value);
+
+module.exports = {
+  DEFAULT_REGION,
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray
+};

--- a/packages/serverless-offline-sqs/src/client-config.js
+++ b/packages/serverless-offline-sqs/src/client-config.js
@@ -8,6 +8,13 @@ const {isNil, omit} = require('lodash/fp');
 // DynamoDB Local, kinesalite) ignore the value but the v3 SDK still requires SOME region to sign.
 const DEFAULT_REGION = 'us-east-1';
 
+// #248 (aws-sdk v3): v3 clients default to maxAttempts:3 with ~150ms total backoff and give up
+// (ECONNRESET "socket hang up") before a freshly-started local emulator (ElasticMQ) finishes
+// booting — aws-sdk v2 tolerated this. A generous default lets the offline plugin ride out the
+// emulator's cold start. A user-supplied `maxAttempts` still wins (it survives in `base` and is
+// spread after this default below).
+const DEFAULT_MAX_ATTEMPTS = 20;
+
 // #252 (aws-sdk v3): build a `credentials` object ONLY when BOTH keys are present. A half-empty
 // `{accessKeyId, secretAccessKey: undefined}` makes the v3 signer throw
 // "Credential is missing" / produces a broken signature, whereas v2 tolerated it. When only one (or
@@ -40,7 +47,9 @@ const buildClientConfig = (options = {}) => {
   return {
     ...base,
     ...(isNil(region) ? {} : {region}),
-    ...(isNil(credentials) ? {} : {credentials})
+    ...(isNil(credentials) ? {} : {credentials}),
+    // Cold-start default; a user-supplied `maxAttempts` (kept in `base`) still wins.
+    maxAttempts: isNil(base.maxAttempts) ? DEFAULT_MAX_ATTEMPTS : base.maxAttempts
   };
 };
 
@@ -51,6 +60,7 @@ const ensureArray = value => (isNil(value) ? [] : value);
 
 module.exports = {
   DEFAULT_REGION,
+  DEFAULT_MAX_ATTEMPTS,
   buildClientConfig,
   buildCredentials,
   resolveRegion,

--- a/packages/serverless-offline-sqs/src/sqs.js
+++ b/packages/serverless-offline-sqs/src/sqs.js
@@ -1,4 +1,10 @@
-const SQSClient = require('aws-sdk/clients/sqs');
+const {
+  SQSClient,
+  CreateQueueCommand,
+  DeleteMessageBatchCommand,
+  GetQueueUrlCommand,
+  ReceiveMessageCommand
+} = require('@aws-sdk/client-sqs');
 
 const {
   assign,
@@ -36,6 +42,7 @@ const {
 } = require('lodash/fp');
 const {default: PQueue} = require('p-queue');
 const {normalizeLog} = require('./log');
+const {buildClientConfig, ensureArray} = require('./client-config');
 const SQSEventDefinition = require('./sqs-event-definition');
 const SQSEvent = require('./sqs-event');
 
@@ -45,6 +52,12 @@ const delay = timeout =>
   new Promise(resolve => {
     setTimeout(resolve, timeout);
   });
+
+// #133/#167 (aws-sdk v3): the "queue does not exist yet" error that gates the createQueue retry is
+// `AWS.SimpleQueueService.NonExistentQueue` on aws-sdk v2 but `QueueDoesNotExist` on @aws-sdk v3 (and
+// some emulators keep the legacy name). Match either so the bounded retry survives the v3 migration.
+const NON_EXISTENT_QUEUE_ERRORS = ['AWS.SimpleQueueService.NonExistentQueue', 'QueueDoesNotExist'];
+const isNonExistentQueueError = err => includes(get('name', err), NON_EXISTENT_QUEUE_ERRORS);
 
 // #253 (flipscholtz): MessageId is not guaranteed unique within a batch and can exceed the 80-char
 // `Id` limit. Derive the batch-entry Id from the array index so it is unique and short.
@@ -292,7 +305,7 @@ class SQS {
     this.options = options;
     this.log = normalizeLog(log);
 
-    this.client = new SQSClient(this.options);
+    this.client = new SQSClient(buildClientConfig(this.options));
 
     this.queue = new PQueue({autoStart: false});
   }
@@ -375,7 +388,7 @@ class SQS {
 
   async _getQueueUrl(queueName) {
     try {
-      return await this.client.getQueueUrl({QueueName: queueName}).promise();
+      return await this.client.send(new GetQueueUrlCommand({QueueName: queueName}));
     } catch (err) {
       await delay(10000);
       return this._getQueueUrl(queueName);
@@ -390,7 +403,7 @@ class SQS {
     if (this.options.autoCreate) await this._createQueue(sqsEvent);
 
     const QueueUrl = this._rewriteQueueUrl(
-      (await this.client.getQueueUrl({QueueName: queueName}).promise()).QueueUrl
+      (await this.client.send(new GetQueueUrlCommand({QueueName: queueName}))).QueueUrl
     );
 
     // #227 (tomusiaka) + #123: use the event-level maximumBatchingWindow as the long-poll wait when
@@ -403,17 +416,20 @@ class SQS {
     const getMessages = async (size, messages = []) => {
       if (size <= 0) return messages;
 
-      const {Messages} = await this.client
-        .receiveMessage({
+      const response = await this.client.send(
+        new ReceiveMessageCommand({
           QueueUrl,
           MaxNumberOfMessages: size > 10 ? 10 : size,
           AttributeNames: ['All'],
           MessageAttributeNames: ['All'],
           WaitTimeSeconds
         })
-        .promise();
+      );
 
-      if (!Messages || Messages.length === 0) return messages;
+      // #248 (aws-sdk v3): v3 OMITS `Messages` from an empty ReceiveMessage response (v2 returned
+      // []). Guard so `.length` never reads `undefined`.
+      const Messages = ensureArray(response.Messages);
+      if (Messages.length === 0) return messages;
       return getMessages(size - Messages.length, [...messages, ...Messages]);
     };
 
@@ -436,12 +452,12 @@ class SQS {
           if (toDelete.length > 0) {
             await Promise.all(
               chunk(10, toDeleteEntries(toDelete)).map(Entries =>
-                this.client
-                  .deleteMessageBatch({
+                this.client.send(
+                  new DeleteMessageBatchCommand({
                     Entries,
                     QueueUrl
                   })
-                  .promise()
+                )
               )
             );
           }
@@ -466,9 +482,9 @@ class SQS {
   async _createQueue({queueName}, remainingTry = 5) {
     try {
       const properties = this._getResourceProperties(queueName);
-      await this.client.createQueue(toCreateQueueParams(queueName, properties)).promise();
+      await this.client.send(new CreateQueueCommand(toCreateQueueParams(queueName, properties)));
     } catch (err) {
-      if (remainingTry > 0 && err.name === 'AWS.SimpleQueueService.NonExistentQueue')
+      if (remainingTry > 0 && isNonExistentQueueError(err))
         return this._createQueue({queueName}, remainingTry - 1);
       this.log.warning(err.stack);
     }
@@ -487,3 +503,4 @@ module.exports.partitionBatchForDeletion = partitionBatchForDeletion;
 module.exports.collectQueueDefinitions = collectQueueDefinitions;
 module.exports.extractDlqTargetName = extractDlqTargetName;
 module.exports.orderQueuesForCreation = orderQueuesForCreation;
+module.exports.isNonExistentQueueError = isNonExistentQueueError;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -15,12 +15,122 @@ const {
   extractDlqTargetName,
   orderQueuesForCreation,
   normalizeQueueNames,
-  expandSqsEventDefinitions
+  expandSqsEventDefinitions,
+  isNonExistentQueueError
 } = require('../src/sqs');
 const SQSEvent = require('../src/sqs-event');
 const SQSEventDefinition = require('../src/sqs-event-definition');
 const {defaultOptions, isPluginEnabled} = require('../src');
 const {extractQueueNameFromARN, resolveCfnValue} = require('../src/sqs-event-definition');
+const {
+  buildClientConfig,
+  buildCredentials,
+  resolveRegion,
+  ensureArray,
+  DEFAULT_REGION
+} = require('../src/client-config');
+
+// ---------------------------------------------------------------------------
+// buildClientConfig (#248/#252 aws-sdk v3 migration)
+// ---------------------------------------------------------------------------
+
+// EARS5: accessKeyId without secretAccessKey must NOT build a half-empty credentials object.
+test('buildCredentials returns undefined when only accessKeyId is provided (EARS5)', t => {
+  t.is(buildCredentials({accessKeyId: 'local'}), undefined);
+});
+
+test('buildCredentials returns undefined when only secretAccessKey is provided', t => {
+  t.is(buildCredentials({secretAccessKey: 'local'}), undefined);
+});
+
+test('buildCredentials returns undefined when neither key is provided', t => {
+  t.is(buildCredentials({}), undefined);
+  t.is(buildCredentials(undefined), undefined);
+});
+
+test('buildCredentials returns a credentials object only when BOTH keys are present', t => {
+  t.deepEqual(buildCredentials({accessKeyId: 'a', secretAccessKey: 's'}), {
+    accessKeyId: 'a',
+    secretAccessKey: 's'
+  });
+});
+
+test('buildCredentials carries sessionToken through only when present', t => {
+  t.deepEqual(buildCredentials({accessKeyId: 'a', secretAccessKey: 's', sessionToken: 't'}), {
+    accessKeyId: 'a',
+    secretAccessKey: 's',
+    sessionToken: 't'
+  });
+});
+
+test('buildClientConfig omits credentials when only accessKeyId is set (EARS5)', t => {
+  const config = buildClientConfig({accessKeyId: 'local', endpoint: 'http://localhost:9324'});
+  t.false('credentials' in config);
+  t.false('accessKeyId' in config);
+});
+
+test('buildClientConfig builds credentials when both keys are set', t => {
+  const config = buildClientConfig({accessKeyId: 'a', secretAccessKey: 's', region: 'eu-west-1'});
+  t.deepEqual(config.credentials, {accessKeyId: 'a', secretAccessKey: 's'});
+  t.false('accessKeyId' in config);
+  t.false('secretAccessKey' in config);
+});
+
+// EARS4: a custom endpoint without provider.region still works (default region supplied).
+test('resolveRegion supplies a default region when endpoint is set and region absent (EARS4)', t => {
+  t.is(resolveRegion({endpoint: 'http://localhost:9324'}), DEFAULT_REGION);
+});
+
+test('resolveRegion keeps the provided region untouched', t => {
+  t.is(resolveRegion({endpoint: 'http://localhost:9324', region: 'eu-west-1'}), 'eu-west-1');
+});
+
+test('resolveRegion returns undefined with no endpoint and no region (default chain owns it)', t => {
+  t.is(resolveRegion({}), undefined);
+});
+
+test('buildClientConfig injects a default region for an endpoint with no region (EARS4)', t => {
+  const config = buildClientConfig({endpoint: 'http://localhost:9324'});
+  t.is(config.region, DEFAULT_REGION);
+  t.is(config.endpoint, 'http://localhost:9324');
+});
+
+test('buildClientConfig passes through unrelated options untouched', t => {
+  const config = buildClientConfig({endpoint: 'http://x', region: 'eu-west-1', maxAttempts: 3});
+  t.is(config.maxAttempts, 3);
+});
+
+test('buildClientConfig does not mutate its input', t => {
+  const options = {accessKeyId: 'a', secretAccessKey: 's', region: 'eu-west-1'};
+  const before = {...options};
+  buildClientConfig(options);
+  t.deepEqual(options, before);
+});
+
+// EARS3: an omitted response array must be treated as [] (no undefined.length crash).
+test('ensureArray returns [] for undefined/null (EARS3)', t => {
+  t.deepEqual(ensureArray(undefined), []);
+  t.deepEqual(ensureArray(null), []);
+});
+
+test('ensureArray returns the array unchanged when present', t => {
+  const records = [{a: 1}];
+  t.is(ensureArray(records), records);
+});
+
+// The createQueue retry guard must match BOTH the v2 and v3 non-existent-queue error names.
+test('isNonExistentQueueError matches the v3 QueueDoesNotExist name', t => {
+  t.true(isNonExistentQueueError({name: 'QueueDoesNotExist'}));
+});
+
+test('isNonExistentQueueError still matches the legacy v2 name', t => {
+  t.true(isNonExistentQueueError({name: 'AWS.SimpleQueueService.NonExistentQueue'}));
+});
+
+test('isNonExistentQueueError is false for an unrelated error', t => {
+  t.false(isNonExistentQueueError({name: 'AccessDenied'}));
+  t.false(isNonExistentQueueError(undefined));
+});
 
 // ---------------------------------------------------------------------------
 // normalizeLog

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -667,13 +667,19 @@ const captureReceiveMessage = async (options, rawDefinition) => {
   const sqs = new SQS(null, {}, {...options, region: 'eu-west-1', accountId: '0'}, undefined);
 
   // replace the real AWS client with a capturing mock; pause the poll queue after the first poll so
-  // the recursive job does not loop forever.
+  // the recursive job does not loop forever. #248 (aws-sdk v3): the production client is driven via
+  // `send(new XCommand(params))`, so dispatch on the command name and read params from `command.input`.
   sqs.client = {
-    getQueueUrl: () => ({promise: () => Promise.resolve({QueueUrl: 'http://local/q'})}),
-    receiveMessage: params => {
-      captured.push(params);
-      sqs.queue.pause();
-      return {promise: () => Promise.resolve({Messages: []})};
+    send: command => {
+      const commandName = command.constructor.name;
+      if (commandName === 'GetQueueUrlCommand')
+        return Promise.resolve({QueueUrl: 'http://local/q'});
+      if (commandName === 'ReceiveMessageCommand') {
+        captured.push(command.input);
+        sqs.queue.pause();
+        return Promise.resolve({Messages: []});
+      }
+      return Promise.resolve({});
     }
   };
 


### PR DESCRIPTION
## What

Repo-wide migration of every plugin off the end-of-support **aws-sdk v2** onto the modular **`@aws-sdk/*` v3** clients.

- **sqs / kinesis / dynamodb-streams / eventbridge**: `require('aws-sdk/clients/X')` -> `@aws-sdk/client-X` v3 `send(new XCommand(...))`; v2 `.waitFor()` -> v3 `waitUntil*` waiters.
- **s3** (minio) and **apigateway-access-logs** (serverless host provider): drop the now-unused `aws-sdk` v2 dependency; no source change required.
- A pure `buildClientConfig(options)` helper per plugin normalizes Serverless-supplied options into a clean v3 client config (credentials only when *both* keys are present; default region injected when an `endpoint` is set but no region is provided).
- The two readable-stream paths (`kinesis-readable`, `dynamodb-streams-readable`) keep driving the client through the v2 *callback* contract via a thin, pure promise->callback shim (`callback-adapter.js`), leaving the readables' logic untouched.

## Why

The aws-sdk v2 has reached end-of-support and prints a noisy `maintenance_mode_message` ("Please migrate your code to use AWS SDK for JavaScript (v3)") on every load. This migration **kills that v2 maintenance-mode warning repo-wide** — including **eventbridge**, because `serverless-offline-dynamodb-streams` imports its `matchesPattern` matcher transitively (`require('serverless-offline-eventbridge/src/eventbridge')`); leaving eventbridge on v2 would keep dragging the warning into the dynamodb-streams path.

## v3 behavioral gaps closed

The v3 clients differ from v2 in two ways that bite the offline emulators:
1. A v3 `GetRecords` / `ReceiveMessage` response **OMITS** the result array entirely when empty (v2 always returned `[]`). Unguarded `response.Records.length` / `.Messages.length` then throws on `undefined`.
2. The v3 signer is stricter about a half-empty `credentials` object and about a missing region when a custom `endpoint` is set.

Both are handled by pure, tested helpers (`ensureArray` / `ensureRecordsResponse`, `buildCredentials`, `resolveRegion`).

## EARS checklist (with evidence)

- [x] **EARS1** — Every plugin source loads only `@aws-sdk/*` v3 clients; no `require('aws-sdk')` remains in any `packages/*/src`.
  - Evidence: `grep -rn "require('aws-sdk')" packages/*/src` -> no matches; `@aws-sdk/client-{dynamodb,dynamodb-streams,kinesis,sqs}` declared across the package.jsons.
- [x] **EARS2** — v2 callback-style readables keep working against v3 promise clients via the pure `callback-adapter` shim (`toCallbackMethod` / `buildCallbackClient`).
  - Evidence: `serverless-offline-kinesis/test/index.js`, `dynamodb-streams-readable/test/v3-unit.js`.
- [x] **EARS3** — An omitted response array is treated as `[]` so the empty-batch poll loop never reads `undefined.length`.
  - Evidence (sqs): `ensureArray` wired at `sqs.js:411`. Evidence (dynamodb-streams): `getOr([], 'Records', data)` guard in `dynamodb-streams-readable/src/index.js`. **Evidence (kinesis, this PR's final commit):** kinesis delegates to third-party `kinesis-readable@1.2.0`, whose `read()` reads `data.Records.length` UNGUARDED; the `callback-adapter` now normalizes the `getRecords` response (`ensureRecordsResponse`) so `Records` defaults to `[]` before it reaches kinesis-readable. Pinned by new AVA tests in `serverless-offline-kinesis/test/index.js`.
- [x] **EARS4** — A custom `endpoint` with no `provider.region` still signs (default region injected).
  - Evidence: `resolveRegion` / `buildClientConfig` tests across all plugins (`...injects a default region for an endpoint with no region (EARS4)`).
- [x] **EARS5** — `accessKeyId` without `secretAccessKey` does NOT build a half-empty `credentials` object (the v3 signer would throw).
  - Evidence: `buildCredentials returns undefined when only one key is provided (EARS5)` across all plugins.
- [x] **EARS6** — No aws-sdk v2 maintenance-mode warning is emitted from any migrated plugin source.
  - Evidence: `node --trace-warnings -e "require('./packages/serverless-offline-kinesis/src')"` -> no warning; same for sqs / eventbridge / s3 / apigateway-access-logs src. (The dynamodb-streams probe still shows the warning *only* under this lerna worktree because the bare `serverless-offline-eventbridge` specifier resolves to the unmigrated master copy in the shared root `node_modules`; once this branch is installed standalone it resolves to the migrated v3 copy and the warning is gone.)
- [ ] **EARS7** — Full integration suite (real ElasticMQ / kinesalite / DynamoDB Local via docker) green. **BLOCKED: docker down** — verify with `cd /tmp/sdd-aws-sdk-v3 && docker-compose up -d && npm run test:integration`.

## Tests

- **303** docker-free unit tests pass (`npx ava` per package): kinesis 31, sqs 105, eventbridge 58, dynamodb-streams 48, ssm-provider 29, apigateway-access-logs 15, s3 13, dynamodb-streams-readable/v3-unit 4.
- `npx eslint packages/serverless-offline-kinesis/` -> clean.
- The only failing tests under the worktree are `dynamodb-streams-readable/test/index.js`, which require DynamoDB Local (docker) and fail with `ECONNREFUSED` — the same EARS7 docker-down condition above.

## Credits

Thanks to @EdgarOrtegaRamirez and @DeeWBee for the groundwork and review on the aws-sdk v3 migration.

Fixes #248
Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
