### PR TITLE
fix(serverless-offline-sqs): resolve a bare {Ref: <QueueLogicalId>} SQS event arn (Fixes #255)

### DIFF
--- a/packages/serverless-offline-sqs/src/index.js
+++ b/packages/serverless-offline-sqs/src/index.js
@@ -57,6 +57,20 @@ const isPluginEnabled = options => {
   return Boolean(enabled);
 };
 
+// #255 (10Bude10, visrut-at-handldigital): an SQS event `arn` may be a bare `{Ref: <QueueLogicalId>}`
+// pointing at a queue declared in resources.Resources — CloudFormation's Ref on an AWS::SQS::Queue
+// yields the queue URL, but offline we only need a stable ARN whose last segment is the queue name.
+// Mirror the Fn::GetAtt Arn branch: resolve a Ref to an AWS::SQS::Queue to its ARN, preferring the
+// declared Properties.QueueName and falling back to the logical id (the name serverless gives an
+// auto-named queue locally). Returns undefined for a Ref to anything that is not an SQS queue (e.g.
+// AWS::* pseudo-params, other resource types) so the caller leaves the intrinsic untouched.
+// Pure + non-throwing.
+const resolveSqsRefArn = (resources, refName, region, accountId) => {
+  if (get([refName, 'Type'], resources) !== 'AWS::SQS::Queue') return undefined;
+  const queueName = get([refName, 'Properties', 'QueueName'], resources) || refName;
+  return `arn:aws:sqs:${region}:${accountId}:${queueName}`;
+};
+
 class ServerlessOfflineSQS {
   constructor(serverless, cliOptions, {log} = {}) {
     this.cliOptions = cliOptions;
@@ -226,26 +240,33 @@ class ServerlessOfflineSQS {
 
           switch (attribute) {
             case 'Arn': {
-              const type = get([resourceName, 'Type'], Resources);
-
-              switch (type) {
-                case 'AWS::SQS::Queue': {
-                  const queueName = get([resourceName, 'Properties', 'QueueName'], Resources);
-                  return [
-                    key,
-                    `arn:aws:sqs:${this.options.region}:${this.options.accountId}:${queueName}`
-                  ];
-                }
-                default: {
-                  return null;
-                }
-              }
+              const arn = resolveSqsRefArn(
+                Resources,
+                resourceName,
+                this.options.region,
+                this.options.accountId
+              );
+              return arn ? [key, arn] : null;
             }
             default: {
               return null;
             }
           }
         }
+
+        // #255: a bare `{Ref: <QueueLogicalId>}` to an AWS::SQS::Queue resolves to that queue's ARN,
+        // mirroring the Fn::GetAtt Arn branch. A Ref to anything else (e.g. AWS pseudo-params) is left
+        // untouched for the downstream resolveCfnValue path.
+        if (has('Ref', value)) {
+          const arn = resolveSqsRefArn(
+            Resources,
+            value.Ref,
+            this.options.region,
+            this.options.accountId
+          );
+          return arn ? [key, arn] : [key, value];
+        }
+
         return [key, this._resolveFn(value)];
       }),
       compact,
@@ -262,3 +283,4 @@ class ServerlessOfflineSQS {
 module.exports = ServerlessOfflineSQS;
 module.exports.defaultOptions = defaultOptions;
 module.exports.isPluginEnabled = isPluginEnabled;
+module.exports.resolveSqsRefArn = resolveSqsRefArn;

--- a/packages/serverless-offline-sqs/test/index.js
+++ b/packages/serverless-offline-sqs/test/index.js
@@ -427,6 +427,107 @@ test('extractQueueNameFromARN keeps a .fifo suffix intact (#189 belongs to the F
 });
 
 // ---------------------------------------------------------------------------
+// #255 (10Bude10, visrut-at-handldigital): an SQS event `arn` given as a bare
+// {Ref: <QueueLogicalId>} pointing at an AWS::SQS::Queue resource must resolve to
+// that queue's ARN so the lambda actually subscribes. Before the fix _resolveFn
+// only handled Fn::GetAtt; a bare Ref fell through unresolved, the queue name
+// became undefined, and GetQueueUrl({QueueName:'undefined'}) never matched.
+// ---------------------------------------------------------------------------
+
+const ResolvableServerlessOfflineSQS = require('../src');
+const {resolveSqsRefArn} = require('../src');
+
+test('#255 resolveSqsRefArn resolves a Ref to an AWS::SQS::Queue to its QueueName ARN', t => {
+  const resources = {
+    fetchIndustryDataQueue: {
+      Type: 'AWS::SQS::Queue',
+      Properties: {QueueName: 'fetchIndustryDataQueue'}
+    }
+  };
+  t.is(
+    resolveSqsRefArn(resources, 'fetchIndustryDataQueue', 'eu-central-1', '000000000000'),
+    'arn:aws:sqs:eu-central-1:000000000000:fetchIndustryDataQueue'
+  );
+});
+
+test('#255 resolveSqsRefArn falls back to the logical id when QueueName is absent', t => {
+  const resources = {OrdersQueue: {Type: 'AWS::SQS::Queue', Properties: {}}};
+  t.is(
+    resolveSqsRefArn(resources, 'OrdersQueue', 'eu-west-1', '0'),
+    'arn:aws:sqs:eu-west-1:0:OrdersQueue'
+  );
+});
+
+test('#255 resolveSqsRefArn returns undefined for a Ref to a non-SQS / unknown resource', t => {
+  const resources = {Bucket: {Type: 'AWS::S3::Bucket', Properties: {BucketName: 'b'}}};
+  t.is(resolveSqsRefArn(resources, 'Bucket', 'eu-west-1', '0'), undefined);
+  t.is(resolveSqsRefArn(resources, 'Missing', 'eu-west-1', '0'), undefined);
+  t.is(resolveSqsRefArn(undefined, 'AWS::Region', 'eu-west-1', '0'), undefined);
+});
+
+test('#255 _resolveFn resolves a bare {Ref: QueueLogicalId} event arn to the queue ARN', t => {
+  // Exact repro of the issue serverless.yml: event arn given as `Ref: fetchIndustryDataQueue`
+  // with the queue declared under resources.Resources and autoCreate:false.
+  const serverless = {
+    service: {
+      resources: {
+        Resources: {
+          fetchIndustryDataQueue: {
+            Type: 'AWS::SQS::Queue',
+            Properties: {QueueName: 'fetchIndustryDataQueue'}
+          }
+        }
+      }
+    }
+  };
+  const plugin = new ResolvableServerlessOfflineSQS(serverless, {}, {});
+  plugin.options = {region: 'eu-central-1', accountId: '000000000000'};
+
+  const resolved = plugin._resolveFn({arn: {Ref: 'fetchIndustryDataQueue'}});
+
+  t.is(resolved.arn, 'arn:aws:sqs:eu-central-1:000000000000:fetchIndustryDataQueue');
+
+  // and the downstream definition must derive the real queue name (not undefined)
+  const sqsEvent = new SQSEventDefinition(resolved, 'eu-central-1', '000000000000');
+  t.is(sqsEvent.queueName, 'fetchIndustryDataQueue');
+});
+
+test('#255 _resolveFn leaves a Ref to a non-SQS resource unresolved (no false ARN)', t => {
+  const serverless = {
+    service: {
+      resources: {Resources: {SomeParam: {Type: 'AWS::SSM::Parameter', Properties: {}}}}
+    }
+  };
+  const plugin = new ResolvableServerlessOfflineSQS(serverless, {}, {});
+  plugin.options = {region: 'eu-west-1', accountId: '0'};
+
+  const resolved = plugin._resolveFn({arn: {Ref: 'SomeParam'}});
+  // unchanged pass-through: still the original intrinsic, NOT a fabricated SQS ARN
+  t.deepEqual(resolved.arn, {Ref: 'SomeParam'});
+});
+
+test('#255 _resolveFn keeps the existing Fn::GetAtt and string-ARN behavior untouched', t => {
+  const serverless = {
+    service: {
+      resources: {
+        Resources: {MyQueue: {Type: 'AWS::SQS::Queue', Properties: {QueueName: 'MyQueue'}}}
+      }
+    }
+  };
+  const plugin = new ResolvableServerlessOfflineSQS(serverless, {}, {});
+  plugin.options = {region: 'eu-west-1', accountId: '000000000000'};
+
+  t.is(
+    plugin._resolveFn({arn: {'Fn::GetAtt': ['MyQueue', 'Arn']}}).arn,
+    'arn:aws:sqs:eu-west-1:000000000000:MyQueue'
+  );
+  t.is(
+    plugin._resolveFn({arn: 'arn:aws:sqs:eu-west-1:000000000000:MyQueue'}).arn,
+    'arn:aws:sqs:eu-west-1:000000000000:MyQueue'
+  );
+});
+
+// ---------------------------------------------------------------------------
 // #166 call-site guard (source-level): the live SQS poll handler must build the
 // event with this.options.region, not the undefined this.region.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #255

## What / why
When an `sqs` event's `arn` is written as a bare CloudFormation `{Ref: <QueueLogicalId>}` pointing at an `AWS::SQS::Queue` declared in `resources.Resources` (with `autoCreate: false`), `serverless-offline-sqs` never triggered the subscribing lambda even though messages reached ElasticMQ. Root cause: `src/index.js#_resolveFn` only resolved `Fn::GetAtt <Q> Arn`; a bare `{Ref: <Q>}` fell through unresolved, and downstream `resolveCfnValue` only resolves `Ref` for AWS pseudo-params, so the queue name became `undefined` and `GetQueueUrl({QueueName: 'undefined'})` never matched the real queue.

This adds a pure, exported `resolveSqsRefArn` helper and a `Ref` branch in `_resolveFn` that resolves a `Ref` to an `AWS::SQS::Queue` to `arn:aws:sqs:<region>:<accountId>:<QueueName>` (preferring `Properties.QueueName`, else the logical id) — mirroring the existing `Fn::GetAtt … Arn` branch, which is refactored to reuse the same helper. A `Ref` to any non-SQS resource (or AWS pseudo-param) is left untouched; string ARNs / `Fn::GetAtt` are unchanged.

## Credit
Thanks to @10Bude10 for the thorough repro (`serverless.yml` + ElasticMQ config) and @visrut-at-handldigital for confirming the same symptom.

## Verification
Failing AVA repro written first and confirmed to FAIL on `origin/master`. After the fix: `npx eslint` clean and `npx ava packages/serverless-offline-sqs/test/index.js` → **123 passed** (incl. 6 new #255 tests). Independently re-run by the orchestrator: green. Unit-level only — no docker / live AWS client.

## Reviewer caveats (non-blocking)
- The shared helper means a `Fn::GetAtt` to a queue **with no** `QueueName` now resolves to the logical id instead of `arn:…:undefined` — strictly an improvement (the `undefined` ARN never matched anything).
- The `Ref` resolution also runs inside `_getResources`, so a `Ref`-form `RedrivePolicy.deadLetterTargetArn` is now resolved too — beneficially correcting DLQ creation ordering (extends #167). Wider but net-positive blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
